### PR TITLE
Add HACS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ A simple Lovelace card for showing drink counts per user. Select a name and the 
 
 ## Installation
 
+### Via HACS
+
+1. Add this repository as a **Custom Repository** in HACS using the
+   **Lovelace** category.
+2. Install the **Drink Counter Card** from the HACS store.
+3. HACS will keep the card up to date.
+
+### Manual
+
 1. Copy `drink-counter-card.js` to your Home Assistant `www` directory.
 2. Add the following to your Lovelace resources:
    ```yaml

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -1,3 +1,4 @@
+// Drink Counter Card v1.0.0
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
 
 class DrinkCounterCard extends LitElement {

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "Drink Counter Card",
+  "content_in_root": true,
+  "filename": "drink-counter-card.js",
+  "render_readme": true,
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary
- add `hacs.json` metadata for HACS
- document installing the card via HACS
- mark the card version in JS file

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687cf4bb9b70832eb5795a13db30e896