### PR TITLE
Remove outdated manual configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,5 @@ A simple Lovelace card for showing and updating drink counts per user. Select a 
 type: custom:drink-counter-card
 ```
 
-### Manual configuration
-
-```yaml
-type: custom:drink-counter-card
-users:
-  - name: Alice
-    drinks:
-      beer: sensor.alice_beer_count
-      water: sensor.alice_water_count
-prices:
-  beer: 2.5
-  water: 1.0
-```
-
-When configured automatically the dropdown lists all users detected from the integration and calculates totals using the stored price list.
+The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required.
 


### PR DESCRIPTION
## Summary
- remove README section about manual configuration and clarify that the card configures itself automatically

## Testing
- `git show --stat --oneline HEAD`

------
https://chatgpt.com/codex/tasks/task_e_687cfb63675c832e9de807dcaacaa556