### PR TITLE
Fix Add button service call capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ type: custom:drink-counter-card
 The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required.
 The selected user's **display name** is sent to the `drink_counter.add_drink` service, so capitalization is preserved.
 
+Pressing **Add** on the Water row triggers a service call like:
+
+```yaml
+action: drink_counter.add_drink
+data:
+  user: Robin
+  drink: Wasser
+```
+

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -68,9 +68,10 @@ class DrinkCounterCard extends LitElement {
   }
 
   _addDrink(drink) {
+    const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
     this.hass.callService('drink_counter', 'add_drink', {
       user: this.selectedUser,
-      drink: drink,
+      drink: displayDrink,
     });
 
     const users = this.config.users || this._autoUsers || [];


### PR DESCRIPTION
## Summary
- format drink name when calling `drink_counter.add_drink`
- document example service call

## Testing
- `node --check drink-counter-card.js`

------
https://chatgpt.com/codex/tasks/task_e_687cfeb9c3c0832e87ed0141a54e703f