### PR TITLE
Change Add button label to +1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ha-drink-counter-lovelace
 
-A simple Lovelace card for showing and updating drink counts per user. Select a name and the card displays how many drinks of each type that user has consumed and the amount owed. Each drink row provides an **Add** button on the left to increment the counter. The table refreshes automatically after adding a drink. The card can automatically read all users and drink prices from the **Drink Counter** integration.
+A simple Lovelace card for showing and updating drink counts per user. Select a name and the card displays how many drinks of each type that user has consumed and the amount owed. Each drink row provides an **+1** button on the left to increment the counter. The table refreshes automatically after adding a drink. The card can automatically read all users and drink prices from the **Drink Counter** integration.
 
 ## Installation
 
@@ -31,7 +31,7 @@ type: custom:drink-counter-card
 The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required.
 The selected user's **display name** is sent to the `drink_counter.add_drink` service, so capitalization is preserved.
 
-Pressing **Add** on the Water row triggers a service call like:
+Pressing **+1** on the Water row triggers a service call like:
 
 ```yaml
 action: drink_counter.add_drink

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -40,7 +40,7 @@ class DrinkCounterCard extends LitElement {
       total += cost;
       const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
       return html`<tr>
-        <td><button @click=${() => this._addDrink(drink)}>Add</button></td>
+        <td><button @click=${() => this._addDrink(drink)}>+1</button></td>
         <td>${displayDrink}</td>
         <td>${count}</td>
         <td>${price}</td>


### PR DESCRIPTION
## Summary
- adjust button label in the drink counter card
- update README instructions to match new button label

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687d003cfe40832eabfb747f73049c4a