### PR TITLE
Add max width setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ If the free amount equals **0 €**, the card hides the **Freibetrag** and **Z
 
 ## UI configuration
 
-The card can now be configured directly in the Lovelace UI. It offers a single option:
+The card can now be configured directly in the Lovelace UI. It offers the following options:
 
 * **Sperrzeit (ms)** – How long the buttons stay disabled after pressing **+1** or **-1**. The default is `1000` milliseconds.
+* **Maximale Breite** – Optional CSS width limit for the card. Useful when using panel views to prevent the layout from stretching too wide.
 

--- a/drink-counter-card-editor.js
+++ b/drink-counter-card-editor.js
@@ -16,7 +16,7 @@ class DrinkCounterCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 1000, ...config };
+    this._config = { lock_ms: 1000, max_width: '', ...config };
   }
 
   render() {
@@ -27,15 +27,29 @@ class DrinkCounterCardEditor extends LitElement {
         <input
           type="number"
           .value=${this._config.lock_ms}
-          @input=${this._valueChanged}
+          @input=${this._lockChanged}
+        />
+      </div>
+      <div class="form">
+        <label>Maximale Breite</label>
+        <input
+          type="text"
+          .value=${this._config.max_width ?? ''}
+          @input=${this._widthChanged}
         />
       </div>
     `;
   }
 
-  _valueChanged(ev) {
+  _lockChanged(ev) {
     const value = Number(ev.target.value);
     this._config = { ...this._config, lock_ms: isNaN(value) ? 1000 : value };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _widthChanged(ev) {
+    const value = ev.target.value;
+    this._config = { ...this._config, max_width: value };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -1,4 +1,4 @@
-// Drink Counter Card v1.3.1
+// Drink Counter Card v1.3.2
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
 
 class DrinkCounterCard extends LitElement {
@@ -16,8 +16,15 @@ class DrinkCounterCard extends LitElement {
   selectedRemoveDrink = '';
 
   setConfig(config) {
-    this.config = { lock_ms: 1000, ...config };
+    this.config = { lock_ms: 1000, max_width: '', ...config };
     this._disabled = false;
+    if (this.config.max_width) {
+      this.style.maxWidth = this.config.max_width;
+      this.style.margin = '0 auto';
+    } else {
+      this.style.removeProperty('max-width');
+      this.style.removeProperty('margin');
+    }
     if (config.users && Array.isArray(config.users)) {
       // Prefer the configured name to preserve capitalization
       this.selectedUser = config.users[0]?.name || config.users[0]?.slug;
@@ -230,10 +237,13 @@ class DrinkCounterCard extends LitElement {
   }
 
   static getStubConfig() {
-    return { lock_ms: 1000 };
+    return { lock_ms: 1000, max_width: '' };
   }
 
   static styles = css`
+    :host {
+      display: block;
+    }
     ha-card {
       padding: 16px;
       text-align: center;
@@ -301,7 +311,7 @@ class DrinkCounterCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 1000, ...config };
+    this._config = { lock_ms: 1000, max_width: '', ...config };
   }
 
   render() {
@@ -312,15 +322,35 @@ class DrinkCounterCardEditor extends LitElement {
         <input
           type="number"
           .value=${this._config.lock_ms}
-          @input=${this._valueChanged}
+          @input=${this._lockChanged}
+        />
+      </div>
+      <div class="form">
+        <label>Maximale Breite</label>
+        <input
+          type="text"
+          .value=${this._config.max_width ?? ''}
+          @input=${this._widthChanged}
         />
       </div>
     `;
   }
 
-  _valueChanged(ev) {
+  _lockChanged(ev) {
     const value = Number(ev.target.value);
     this._config = { ...this._config, lock_ms: isNaN(value) ? 1000 : value };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _widthChanged(ev) {
+    const value = ev.target.value;
+    this._config = { ...this._config, max_width: value };
     this.dispatchEvent(
       new CustomEvent('config-changed', {
         detail: { config: this._config },

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "drink-counter-card.js",
   "render_readme": true,
-  "version": "1.3.1"
+  "version": "1.3.2"
 }


### PR DESCRIPTION
## Summary
- add an optional `max_width` configuration to limit card width
- expose the setting in the Lovelace editor
- document available options in README
- bump component version to 1.3.2

## Testing
- `node --check drink-counter-card.js`
- `node --check drink-counter-card-editor.js`


------
https://chatgpt.com/codex/tasks/task_e_687e708e0ad8832e9ac6ea9d2468ab9c