### PR TITLE
Add ranking view module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A simple Lovelace card for showing and updating drink counts per user. Select a 
 
 ### Manual
 
-1. Copy `drink-counter-card.js` to your Home Assistant `www` directory.
+1. Copy `drink-counter-card.js` **and** `ranking-view.js` to your Home Assistant `www` directory.
 2. Add the following to your Lovelace resources:
    ```yaml
   - url: /local/drink-counter-card.js
@@ -61,10 +61,15 @@ When sensors named `sensor.<name>_amount_due` are present, their values are used
 
 If the free amount equals **0 €**, the card hides the **Freibetrag** and **Zu zahlen** rows and only shows the **Gesamt** line.
 
+## Ranking view
+
+Selecting **Ranking** from the card options shows a table of all users ordered by how much they need to pay.
+
 ## UI configuration
 
 The card can now be configured directly in the Lovelace UI. It offers the following options:
 
 * **Sperrzeit (ms)** – How long the buttons stay disabled after pressing **+1** or **-1**. The default is `1000` milliseconds.
 * **Maximale Breite (px)** – Optional width limit for the card in pixels. Enter a number and the `px` unit is added automatically. Useful when using panel views to prevent the layout from stretching too wide.
+* **Widget** – Choose between the standard drink counter or the ranking table.
 

--- a/drink-counter-card-editor.js
+++ b/drink-counter-card-editor.js
@@ -16,7 +16,7 @@ class DrinkCounterCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 1000, max_width: '', ...config };
+    this._config = { lock_ms: 1000, max_width: '', view: 'counter', ...config };
   }
 
   render() {
@@ -29,6 +29,13 @@ class DrinkCounterCardEditor extends LitElement {
           .value=${this._config.lock_ms}
           @input=${this._lockChanged}
         />
+      </div>
+      <div class="form">
+        <label>Widget</label>
+        <select .value=${this._config.view} @change=${this._viewChanged}>
+          <option value="counter">Zähler</option>
+          <option value="ranking">Ranking</option>
+        </select>
       </div>
       <div class="form">
         <label>Maximale Breite (px)</label>
@@ -47,6 +54,12 @@ class DrinkCounterCardEditor extends LitElement {
     fireEvent(this, 'config-changed', { config: this._config });
   }
 
+  _viewChanged(ev) {
+    const value = ev.target.value;
+    this._config = { ...this._config, view: value };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
   _widthChanged(ev) {
     const raw = ev.target.value.trim();
     const width = raw ? `${raw}px` : '';
@@ -58,7 +71,8 @@ class DrinkCounterCardEditor extends LitElement {
     .form {
       padding: 16px;
     }
-    input {
+    input,
+    select {
       width: 100%;
       box-sizing: border-box;
     }

--- a/drink-counter-card.js
+++ b/drink-counter-card.js
@@ -1,5 +1,6 @@
 // Drink Counter Card v1.3.5
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
+import { renderRanking } from './ranking-view.js';
 
 window.customCards = window.customCards || [];
 window.customCards.push({
@@ -24,7 +25,7 @@ class DrinkCounterCard extends LitElement {
   selectedRemoveDrink = '';
 
   setConfig(config) {
-    this.config = { lock_ms: 1000, max_width: '', ...config };
+    this.config = { lock_ms: 1000, max_width: '', view: 'counter', ...config };
     this._disabled = false;
     const width = this._normalizeWidth(this.config.max_width);
     if (width) {
@@ -44,6 +45,17 @@ class DrinkCounterCard extends LitElement {
 
   render() {
     if (!this.hass || !this.config) return html``;
+    if (this.config.view === 'ranking') {
+      const width = this._normalizeWidth(this.config.max_width);
+      return renderRanking({
+        hass: this.hass,
+        config: this.config,
+        autoUsers: this._autoUsers,
+        autoPrices: this._autoPrices,
+        freeAmount: this._freeAmount,
+        width,
+      });
+    }
     const users = this.config.users || this._autoUsers || [];
     if (!this.selectedUser && users.length > 0) {
       // Default to the display name if available
@@ -121,6 +133,7 @@ class DrinkCounterCard extends LitElement {
       </ha-card>
     `;
   }
+
 
   _selectUser(ev) {
     this.selectedUser = ev.target.value;
@@ -255,7 +268,7 @@ class DrinkCounterCard extends LitElement {
   }
 
   static getStubConfig() {
-    return { lock_ms: 1000, max_width: '' };
+    return { lock_ms: 1000, max_width: '', view: 'counter' };
   }
 
   static styles = css`
@@ -331,7 +344,7 @@ class DrinkCounterCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 1000, max_width: '', ...config };
+    this._config = { lock_ms: 1000, max_width: '', view: 'counter', ...config };
   }
 
   render() {
@@ -344,6 +357,13 @@ class DrinkCounterCardEditor extends LitElement {
           .value=${this._config.lock_ms}
           @input=${this._lockChanged}
         />
+      </div>
+      <div class="form">
+        <label>Widget</label>
+        <select .value=${this._config.view} @change=${this._viewChanged}>
+          <option value="counter">Zähler</option>
+          <option value="ranking">Ranking</option>
+        </select>
       </div>
       <div class="form">
         <label>Maximale Breite (px)</label>
@@ -359,6 +379,18 @@ class DrinkCounterCardEditor extends LitElement {
   _lockChanged(ev) {
     const value = Number(ev.target.value);
     this._config = { ...this._config, lock_ms: isNaN(value) ? 1000 : value };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _viewChanged(ev) {
+    const value = ev.target.value;
+    this._config = { ...this._config, view: value };
     this.dispatchEvent(
       new CustomEvent('config-changed', {
         detail: { config: this._config },
@@ -385,7 +417,8 @@ class DrinkCounterCardEditor extends LitElement {
     .form {
       padding: 16px;
     }
-    input {
+    input,
+    select {
       width: 100%;
       box-sizing: border-box;
     }

--- a/ranking-view.js
+++ b/ranking-view.js
@@ -1,0 +1,35 @@
+import { html } from 'https://unpkg.com/lit?module';
+
+export function renderRanking({hass, config, autoUsers, autoPrices, freeAmount, width}) {
+  const users = config.users || autoUsers || [];
+  const prices = config.prices || autoPrices || {};
+  const free = Number(config.free_amount ?? freeAmount ?? 0);
+  const rows = users.map(u => {
+    let total = 0;
+    for (const [drink, entity] of Object.entries(u.drinks)) {
+      const count = Number(hass.states[entity]?.state || 0);
+      const price = Number(prices[drink] || 0);
+      total += count * price;
+    }
+    let due;
+    if (u.amount_due_entity) {
+      const s = hass.states[u.amount_due_entity];
+      const v = parseFloat(s?.state);
+      due = isNaN(v) ? Math.max(total - free, 0) : v;
+    } else {
+      due = Math.max(total - free, 0);
+    }
+    return { name: u.name || u.slug, due };
+  }).sort((a, b) => b.due - a.due);
+  const cardStyle = width ? `max-width:${width};margin:0 auto;` : '';
+  return html`
+    <ha-card style="${cardStyle}">
+      <table>
+        <thead><tr><th>Name</th><th>Zu zahlen</th></tr></thead>
+        <tbody>
+          ${rows.map(r => html`<tr><td>${r.name}</td><td>${r.due.toFixed(2)} €</td></tr>`)}
+        </tbody>
+      </table>
+    </ha-card>
+  `;
+}


### PR DESCRIPTION
## Summary
- extract ranking view into new `ranking-view.js`
- import `renderRanking` function in card
- document copying new script for manual setup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e86ea1620832ebb41f96460abcc60