### PR TITLE
Restrict user selection to linked person

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ adjust the lock time without writing YAML.
 type: custom:drink-counter-card
 ```
 
-The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required.
+The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required. Normal users can only select themselves, while admins may choose any person.
 The selected user's **display name** is sent to the `drink_counter.add_drink` service, so capitalization is preserved.
 
 Pressing **+1** on the Water row triggers a service call like:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-drink-counter-lovelace",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A simple Lovelace card for showing and updating drink counts per user",
   "main": "drink-counter-card.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- enforce user selection based on logged-in user
- track `user_id` from linked `person` entities
- document new permission behavior
- bump version to 1.4.0

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fc154c18c832e9cca567239e11d1f