### PR TITLE
Ensure admins default to their own user

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -58,8 +58,10 @@ class TallyListCard extends LitElement {
       return html`<ha-card>Kein Zugriff auf Nutzer</ha-card>`;
     }
     if (!this.selectedUser || !users.some(u => (u.name || u.slug) === this.selectedUser)) {
-      // Default to the display name if available
-      this.selectedUser = users[0].name || users[0].slug;
+      const uid = this.hass.user?.id;
+      const own = users.find(u => u.user_id === uid);
+      // Prefer the current user when available, otherwise pick the first entry
+      this.selectedUser = (own?.name || own?.slug) ?? (users[0].name || users[0].slug);
     }
     const user = users.find(u => (u.name || u.slug) === this.selectedUser);
     if (!user) return html`<ha-card>Unbekannter Benutzer</ha-card>`;


### PR DESCRIPTION
## Summary
- default the selected user to the viewer's account when possible

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fc6f277b8832e933a5e985e4df8cf