### PR TITLE
Fix default user selection for admins

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -56,7 +56,11 @@ class TallyListCard extends LitElement {
     }
     if (!this.selectedUser || !users.some(u => (u.name || u.slug) === this.selectedUser)) {
       const uid = this.hass.user?.id;
-      const own = users.find(u => u.user_id === uid);
+      let own = users.find(u => u.user_id === uid);
+      if (!own) {
+        const uname = (this.hass.user?.name || '').toLowerCase();
+        own = users.find(u => (u.name || '').toLowerCase() === uname || u.slug === uname);
+      }
       // Prefer the current user when available, otherwise pick the first entry
       this.selectedUser = (own?.name || own?.slug) ?? (users[0].name || users[0].slug);
     }


### PR DESCRIPTION
## Summary
- improve default selection logic to prefer logged-in admin

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fc964ba94832ea94d8af2f67d5b7d