### PR TITLE
Add card version info to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,5 @@ The card can now be configured directly in the Lovelace UI. It offers the follow
 
 * **Sperrzeit (ms)** – How long the buttons stay disabled after pressing **+1** or **-1**. The default is `1000` milliseconds.
 * **Maximale Breite (px)** – Optional width limit for the card in pixels. Enter a number and the `px` unit is added automatically. Useful when using panel views to prevent the layout from stretching too wide.
+* **Version** – Displays the installed card version.
 

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
+const CARD_VERSION = '1.4.0';
 
 function fireEvent(node, type, detail = {}, options = {}) {
   node.dispatchEvent(
@@ -38,6 +39,7 @@ class TallyListCardEditor extends LitElement {
           @input=${this._widthChanged}
         />
       </div>
+      <div class="version">Version: ${CARD_VERSION}</div>
     `;
   }
 
@@ -61,6 +63,11 @@ class TallyListCardEditor extends LitElement {
     input {
       width: 100%;
       box-sizing: border-box;
+    }
+    .version {
+      padding: 0 16px 16px;
+      text-align: center;
+      color: var(--secondary-text-color);
     }
   `;
 }

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,5 +1,6 @@
 // Tally List Card v1.4.0
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
+const CARD_VERSION = '1.4.0';
 
 window.customCards = window.customCards || [];
 window.customCards.push({
@@ -385,6 +386,7 @@ class TallyListCardEditor extends LitElement {
           @input=${this._widthChanged}
         />
       </div>
+      <div class="version">Version: ${CARD_VERSION}</div>
     `;
   }
 
@@ -420,6 +422,11 @@ class TallyListCardEditor extends LitElement {
     input {
       width: 100%;
       box-sizing: border-box;
+    }
+    .version {
+      padding: 0 16px 16px;
+      text-align: center;
+      color: var(--secondary-text-color);
     }
   `;
 }


### PR DESCRIPTION
## Summary
- display current card version number in the editor
- document version info in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fdda0fd04832e8cb59cdc31dcad18