### PR TITLE
Sort users alphabetically and show current user first

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ type: custom:tally-list-card
 ```
 
 The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required. Normal users can only select themselves, while admins may choose any person.
-The selected user's **display name** is sent to the `tally_list.add_drink` service, so capitalization is preserved.
+When a `person.<slug>` entity exists, its friendly name is used in the dropdown; otherwise the name comes from the tally sensors. The selected user's **display name** is sent to the `tally_list.add_drink` service, so capitalization is preserved.
 
 Pressing **+1** on the Water row triggers a service call like:
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -57,11 +57,15 @@ class TallyListCard extends LitElement {
     if (users.length === 0) {
       return html`<ha-card>Kein Zugriff auf Nutzer</ha-card>`;
     }
+    const uid = this.hass.user?.id;
+    const own = users.find(u => u.user_id === uid);
+    users = [...users].sort((a, b) => (a.name || a.slug).localeCompare(b.name || b.slug));
+    if (own) {
+      users = [own, ...users.filter(u => u !== own)];
+    }
     if (!this.selectedUser || !users.some(u => (u.name || u.slug) === this.selectedUser)) {
-      const uid = this.hass.user?.id;
-      const own = users.find(u => u.user_id === uid);
       // Prefer the current user when available, otherwise pick the first entry
-      this.selectedUser = (own?.name || own?.slug) ?? (users[0].name || users[0].slug);
+      this.selectedUser = own ? (own.name || own.slug) : (users[0].name || users[0].slug);
     }
     const user = users.find(u => (u.name || u.slug) === this.selectedUser);
     if (!user) return html`<ha-card>Unbekannter Benutzer</ha-card>`;
@@ -220,7 +224,7 @@ class TallyListCard extends LitElement {
       const match = entity.match(/^sensor\.([a-z0-9_]+)_amount_due$/);
       if (match) {
         const slug = match[1];
-        const name = (state.attributes.friendly_name || '').replace(' Amount Due', '');
+        const sensorName = (state.attributes.friendly_name || '').replace(' Amount Due', '');
         const drinks = {};
         const prefix = `sensor.${slug}_`;
         for (const [e2] of Object.entries(states)) {
@@ -232,7 +236,9 @@ class TallyListCard extends LitElement {
         }
         const person = states[`person.${slug}`];
         const user_id = person?.attributes?.user_id || null;
-        users.push({ name: name || slug, slug, drinks, amount_due_entity: entity, user_id });
+        const personName = person?.attributes?.friendly_name;
+        const name = personName || sensorName || slug;
+        users.push({ name, slug, drinks, amount_due_entity: entity, user_id });
       }
     }
     return users;


### PR DESCRIPTION
## Summary
- keep the logged in user at the top of the dropdown
- sort the remaining users alphabetically
- use person friendly name when available

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fcd66e934832e850266daed80de14