### PR TITLE
Sort users alphabetically and show current user first

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ type: custom:tally-list-card
 ```
 
 The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required. Normal users can only select themselves, while admins may choose any person.
-The selected user's **display name** is sent to the `tally_list.add_drink` service, so capitalization is preserved.
+When a `person.<slug>` entity exists, its friendly name is used in the dropdown; otherwise the name comes from the tally sensors. Users are sorted alphabetically and the currently logged in user always appears first. The selected user's **display name** is sent to the `tally_list.add_drink` service, so capitalization is preserved.
 
 Pressing **+1** on the Water row triggers a service call like:
 


### PR DESCRIPTION
## Summary
- keep the logged in user at the top of the dropdown
- sort the remaining users alphabetically
- use person friendly name when available

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fcd66e934832e850266daed80de14