### PR TITLE
Improve slug detection for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ type: custom:tally-list-card
 The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required. Normal users can only select themselves, while admins may choose any person.
 
 When a `person.<slug>` entity exists, its friendly name is used in the dropdown; otherwise the name comes from the tally sensors. Users are sorted alphabetically and the currently logged in user always appears first. The selected user's **display name** is sent to the `tally_list.add_drink` service, so capitalization is preserved.
+The card also matches the sensor slug against the person's friendly name, so mismatched slugs still detect the current user.
 
 Pressing **+1** on the Water row triggers a service call like:
 


### PR DESCRIPTION
## Summary
- match sensor slugs using slugified person names
- add helper to slugify names
- allow `_currentPersonSlugs()` to include slugified friendly names
- document friendly-name matching

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fe77d6548832ebbe08ba32eaaa32e