### PR TITLE
Add due ranking Lovelace card

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,13 @@ The card can now be configured directly in the Lovelace UI. It offers the follow
 * **Maximale Breite (px)** – Optional width limit for the card in pixels. Enter a number and the `px` unit is added automatically. Useful when using panel views to prevent the layout from stretching too wide.
 * **Version** – Displays the installed card version.
 
+## Zu zahlen Rangliste
+
+Zusätzlich zur eigentlichen Karte steht eine zweite Lovelace-Karte zur Verfügung, die alle Nutzer nach dem offenen Betrag sortiert anzeigt.
+
+```yaml
+type: custom:tally-due-ranking-card
+```
+
+Im Editor lässt sich ebenfalls eine maximale Breite in Pixel festlegen.
+


### PR DESCRIPTION
## Summary
- register an additional card in `tally-list-card.js`
- implement `tally-due-ranking-card` with editor
- describe new card in README

## Testing
- `npm test` *(fails: missing script)*
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68811b724cb0832e956e9f1ead9ed547