### PR TITLE
Add helper functions to due ranking card

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,13 @@ The card can now be configured directly in the Lovelace UI. It offers the follow
 * **Maximale Breite (px)** – Optional width limit for the card in pixels. Enter a number and the `px` unit is added automatically. Useful when using panel views to prevent the layout from stretching too wide.
 * **Version** – Displays the installed card version.
 
+## Zu zahlen Rangliste
+
+Zusätzlich zur eigentlichen Karte steht eine zweite Lovelace-Karte zur Verfügung, die alle Nutzer nach dem offenen Betrag sortiert anzeigt.
+
+```yaml
+type: custom:tally-due-ranking-card
+```
+
+Im Editor lässt sich ebenfalls eine maximale Breite in Pixel festlegen.
+

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -9,6 +9,12 @@ window.customCards.push({
   preview: true,
   description: 'Displays drink counts per user with quick add/remove buttons.',
 });
+window.customCards.push({
+  type: 'tally-due-ranking-card',
+  name: 'Tally Due Ranking Card',
+  preview: true,
+  description: 'Shows a ranking based on the due amount per user.',
+});
 
 class TallyListCard extends LitElement {
   static properties = {
@@ -462,4 +468,230 @@ class TallyListCardEditor extends LitElement {
 }
 
 customElements.define('tally-list-card-editor', TallyListCardEditor);
+
+class TallyDueRankingCard extends LitElement {
+  static properties = {
+    hass: {},
+    config: {},
+    _autoUsers: { state: true },
+    _autoPrices: { state: true },
+    _freeAmount: { state: true },
+  };
+
+  setConfig(config) {
+    this.config = { max_width: '', ...config };
+    const width = this._normalizeWidth(this.config.max_width);
+    if (width) {
+      this.style.setProperty('--dcc-max-width', width);
+      this.config.max_width = width;
+    } else {
+      this.style.removeProperty('--dcc-max-width');
+      this.config.max_width = '';
+    }
+  }
+
+  render() {
+    if (!this.hass || !this.config) return html``;
+    let users = this.config.users || this._autoUsers || [];
+    if (users.length === 0) {
+      return html`<ha-card>Strichliste-Integration nicht gefunden. Bitte richte die Integration ein.</ha-card>`;
+    }
+    const isAdmin = this.hass.user?.is_admin;
+    if (!isAdmin) {
+      const allowed = this._currentPersonSlugs();
+      const uid = this.hass.user?.id;
+      users = users.filter(u => u.user_id === uid || allowed.includes(u.slug));
+    }
+    if (users.length === 0) {
+      return html`<ha-card>Kein Zugriff auf Nutzer</ha-card>`;
+    }
+    const prices = this.config.prices || this._autoPrices || {};
+    const freeAmount = Number(this.config.free_amount ?? this._freeAmount ?? 0);
+    const ranking = users.map(u => {
+      let total = 0;
+      for (const [drink, entity] of Object.entries(u.drinks)) {
+        const count = Number(this.hass.states[entity]?.state || 0);
+        const price = Number(prices[drink] || 0);
+        total += count * price;
+      }
+      let due;
+      if (u.amount_due_entity) {
+        const s = this.hass.states[u.amount_due_entity];
+        const val = parseFloat(s?.state);
+        due = isNaN(val) ? Math.max(total - freeAmount, 0) : val;
+      } else {
+        due = Math.max(total - freeAmount, 0);
+      }
+      return { name: u.name || u.slug, due };
+    });
+    ranking.sort((a, b) => b.due - a.due);
+    const rows = ranking.map((r, i) => html`<tr><td>${i + 1}</td><td>${r.name}</td><td>${r.due.toFixed(2)} €</td></tr>`);
+    const width = this._normalizeWidth(this.config.max_width);
+    const cardStyle = width ? `max-width:${width};margin:0 auto;` : '';
+    return html`
+      <ha-card style="${cardStyle}">
+        <table>
+          <thead><tr><th>#</th><th>Name</th><th>Zu zahlen</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </ha-card>
+    `;
+  }
+
+  updated(changedProps) {
+    if (changedProps.has('hass')) {
+      if (!this.config.users) {
+        this._autoUsers = this._gatherUsers();
+      }
+      if (!this.config.prices) {
+        this._autoPrices = this._gatherPrices();
+      }
+      if (!this.config.free_amount) {
+        this._freeAmount = this._gatherFreeAmount();
+      }
+    }
+  }
+
+  static async getConfigElement() {
+    return document.createElement('tally-due-ranking-card-editor');
+  }
+
+  static getStubConfig() {
+    return { max_width: '' };
+  }
+
+  _gatherUsers() {
+    const users = [];
+    const states = this.hass.states;
+    for (const [entity, state] of Object.entries(states)) {
+      const match = entity.match(/^sensor\.([a-z0-9_]+)_amount_due$/);
+      if (match) {
+        const slug = match[1];
+        const sensorName = (state.attributes.friendly_name || '').replace(' Amount Due', '');
+        const drinks = {};
+        const prefix = `sensor.${slug}_`;
+        for (const [e2] of Object.entries(states)) {
+          const m2 = e2.startsWith(prefix) && e2.endsWith('_count') && e2.match(/^sensor\.[a-z0-9_]+_([^_]+)_count$/);
+          if (m2) {
+            const drink = m2[1];
+            drinks[drink] = e2;
+          }
+        }
+        let person = states[`person.${slug}`];
+        if (!person) {
+          for (const [pEntity, pState] of Object.entries(states)) {
+            if (pEntity.startsWith('person.') && this._slugify(pState.attributes?.friendly_name || '') === slug) {
+              person = pState;
+              break;
+            }
+          }
+        }
+        const user_id = person?.attributes?.user_id || null;
+        const personName = person?.attributes?.friendly_name;
+        const name = personName || sensorName || slug;
+        users.push({ name, slug, drinks, amount_due_entity: entity, user_id });
+      }
+    }
+    return users;
+  }
+
+  _gatherPrices() {
+    const prices = {};
+    const states = this.hass.states;
+    for (const [entity, state] of Object.entries(states)) {
+      const match = entity.match(/^sensor\.preisliste_([^_]+)_price$/);
+      if (match) {
+        const drink = match[1];
+        const price = parseFloat(state.state);
+        prices[drink] = isNaN(price) ? 0 : price;
+      }
+    }
+    return prices;
+  }
+
+  _gatherFreeAmount() {
+    const state = this.hass.states['sensor.preisliste_free_amount'];
+    if (!state) return 0;
+    const val = parseFloat(state.state);
+    return isNaN(val) ? 0 : val;
+  }
+
+  _slugify(str) {
+    if (!str) return '';
+    return str
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '');
+  }
+
+  _currentPersonSlugs() {
+    const userId = this.hass.user?.id;
+    if (!userId) return [];
+    const slugs = [];
+    for (const [entity, state] of Object.entries(this.hass.states)) {
+      if (entity.startsWith('person.') && state.attributes.user_id === userId) {
+        const slug = entity.substring('person.'.length);
+        slugs.push(slug);
+        const alt = this._slugify(state.attributes.friendly_name || '');
+        if (alt && alt !== slug) {
+          slugs.push(alt);
+        }
+      }
+    }
+    return slugs;
+  }
+
+  _normalizeWidth(value) {
+    if (!value && value !== 0) return '';
+    const str = String(value).trim();
+    if (str === '') return '';
+    return /^\d+$/.test(str) ? `${str}px` : str;
+  }
+}
+
+customElements.define('tally-due-ranking-card', TallyDueRankingCard);
+
+class TallyDueRankingCardEditor extends LitElement {
+  static properties = {
+    _config: {},
+  };
+
+  setConfig(config) {
+    this._config = { max_width: '', ...config };
+  }
+
+  render() {
+    if (!this._config) return html``;
+    return html`
+      <div class="form">
+        <label>Maximale Breite (px)</label>
+        <input
+          type="number"
+          .value=${(this._config.max_width ?? '').replace(/px$/, '')}
+          @input=${this._widthChanged}
+        />
+      </div>
+      <div class="version">Version: ${CARD_VERSION}</div>
+    `;
+  }
+
+  _widthChanged(ev) {
+    const raw = ev.target.value.trim();
+    const width = raw ? `${raw}px` : '';
+    this._config = { ...this._config, max_width: width };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  static styles = TallyListCardEditor.styles;
+}
+
+customElements.define('tally-due-ranking-card-editor', TallyDueRankingCardEditor);
 


### PR DESCRIPTION
## Summary
- fix error when configuring `tally-due-ranking-card`
- copy helper functions from main card so the new card works

## Testing
- `npm test` *(fails: missing script)*
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68811b724cb0832e956e9f1ead9ed547