### PR TITLE
Implement configurable sorting for ranking card

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,11 @@ Zusätzlich zur eigentlichen Karte steht eine zweite Lovelace-Karte zur Verfügu
 type: custom:tally-due-ranking-card
 ```
 
-Im Editor lässt sich ebenfalls eine maximale Breite in Pixel festlegen.
+Im Editor lässt sich ebenfalls eine maximale Breite in Pixel festlegen. Über die Option `sort_by` kann die Reihenfolge wahlweise alphabetisch oder aufsteigend nach dem offenen Betrag erfolgen. Mit `sort_menu: true` erscheint ein Dropdown, über das die Sortierung direkt gewechselt werden kann.
+
+```yaml
+type: custom:tally-due-ranking-card
+sort_by: name  # oder due_desc (Standard) oder due_asc
+sort_menu: true
+```
 

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "tally-list-card.js",
   "render_readme": true,
-  "version": "1.4.0"
+  "version": "1.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.4.0';
+const CARD_VERSION = '1.6.0';
 
 function fireEvent(node, type, detail = {}, options = {}) {
   node.dispatchEvent(

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,6 @@
-// Tally List Card v1.4.0
+// Tally List Card v1.6.0
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.4.0';
+const CARD_VERSION = '1.6.0';
 
 window.customCards = window.customCards || [];
 window.customCards.push({
@@ -476,10 +476,12 @@ class TallyDueRankingCard extends LitElement {
     _autoUsers: { state: true },
     _autoPrices: { state: true },
     _freeAmount: { state: true },
+    _sortBy: { state: true },
   };
 
   setConfig(config) {
-    this.config = { max_width: '', ...config };
+    this.config = { max_width: '', sort_by: 'due_desc', sort_menu: false, ...config };
+    this._sortBy = this.config.sort_by;
     const width = this._normalizeWidth(this.config.max_width);
     if (width) {
       this.style.setProperty('--dcc-max-width', width);
@@ -524,12 +526,34 @@ class TallyDueRankingCard extends LitElement {
       }
       return { name: u.name || u.slug, due };
     });
-    ranking.sort((a, b) => b.due - a.due);
+    const sortBy = this._sortBy || this.config.sort_by || 'due_desc';
+    ranking.sort((a, b) => {
+      switch (sortBy) {
+        case 'name':
+          return a.name.localeCompare(b.name);
+        case 'due_asc':
+          return a.due - b.due;
+        case 'due_desc':
+        default:
+          return b.due - a.due;
+      }
+    });
     const rows = ranking.map((r, i) => html`<tr><td>${i + 1}</td><td>${r.name}</td><td>${r.due.toFixed(2)} €</td></tr>`);
     const width = this._normalizeWidth(this.config.max_width);
     const cardStyle = width ? `max-width:${width};margin:0 auto;` : '';
+    const sortMenu = this.config.sort_menu
+      ? html`<div class="controls">
+          <label>Sortierung:</label>
+          <select @change=${this._sortMenuChanged}>
+            <option value="due_desc" ?selected=${sortBy === 'due_desc'}>Nach offenem Betrag</option>
+            <option value="due_asc" ?selected=${sortBy === 'due_asc'}>Nach offenem Betrag (aufsteigend)</option>
+            <option value="name" ?selected=${sortBy === 'name'}>Alphabetisch</option>
+          </select>
+        </div>`
+      : '';
     return html`
       <ha-card style="${cardStyle}">
+        ${sortMenu}
         <table>
           <thead><tr><th>#</th><th>Name</th><th>Zu zahlen</th></tr></thead>
           <tbody>${rows}</tbody>
@@ -557,7 +581,7 @@ class TallyDueRankingCard extends LitElement {
   }
 
   static getStubConfig() {
-    return { max_width: '' };
+    return { max_width: '', sort_by: 'due_desc', sort_menu: false };
   }
   _gatherUsers() {
     const users = [];
@@ -648,6 +672,10 @@ class TallyDueRankingCard extends LitElement {
     if (str === '') return '';
     return /^\d+$/.test(str) ? `${str}px` : str;
   }
+
+  _sortMenuChanged(ev) {
+    this._sortBy = ev.target.value;
+  }
 }
 
 customElements.define('tally-due-ranking-card', TallyDueRankingCard);
@@ -658,7 +686,7 @@ class TallyDueRankingCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { max_width: '', ...config };
+    this._config = { max_width: '', sort_by: 'due_desc', sort_menu: false, ...config };
   }
 
   render() {
@@ -672,6 +700,26 @@ class TallyDueRankingCardEditor extends LitElement {
           @input=${this._widthChanged}
         />
       </div>
+      <div class="form">
+        <label>Sortierung</label>
+        <select @change=${this._sortChanged}>
+          <option value="due_desc" ?selected=${this._config.sort_by === 'due_desc'}>
+            Nach offenem Betrag
+          </option>
+          <option value="due_asc" ?selected=${this._config.sort_by === 'due_asc'}>
+            Nach offenem Betrag (aufsteigend)
+          </option>
+          <option value="name" ?selected=${this._config.sort_by === 'name'}>
+            Alphabetisch
+          </option>
+        </select>
+      </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.sort_menu} @change=${this._menuChanged} />
+          Sortiermenü anzeigen
+        </label>
+      </div>
       <div class="version">Version: ${CARD_VERSION}</div>
     `;
   }
@@ -680,6 +728,29 @@ class TallyDueRankingCardEditor extends LitElement {
     const raw = ev.target.value.trim();
     const width = raw ? `${raw}px` : '';
     this._config = { ...this._config, max_width: width };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _sortChanged(ev) {
+    const val = ev.target.value;
+    this._config = { ...this._config, sort_by: val };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _menuChanged(ev) {
+    this._config = { ...this._config, sort_menu: ev.target.checked };
     this.dispatchEvent(
       new CustomEvent('config-changed', {
         detail: { config: this._config },


### PR DESCRIPTION
## Summary
- add option `sort_menu` to display a dropdown for on-card sorting
- allow card users to switch between alphabetical and due amount order
- document the new option and example usage
- bump version to 1.6.0

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68812122cfbc832e99c5c7dcd4b75b67