### PR TITLE
Fix checkbox alignment in ranking card editor

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -455,7 +455,8 @@ class TallyListCardEditor extends LitElement {
     .form {
       padding: 16px;
     }
-    input {
+    input[type='number'],
+    input[type='text'] {
       width: 100%;
       box-sizing: border-box;
     }


### PR DESCRIPTION
## Summary
- prevent checkbox from taking full width in ranking card editor

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68812cb9e358832e973e17798b9d0aff