### PR TITLE
Improve Ranking card sorting UI

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -480,6 +480,27 @@ class TallyDueRankingCard extends LitElement {
     _sortBy: { state: true },
   };
 
+  static styles = [
+    TallyListCard.styles,
+    css`
+      .controls {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 8px;
+        flex-wrap: wrap;
+      }
+      .controls select {
+        padding: 4px 8px;
+        min-width: 160px;
+        font-size: 1rem;
+        height: 40px;
+        box-sizing: border-box;
+      }
+    `,
+  ];
+
   setConfig(config) {
     this.config = { max_width: '', sort_by: 'due_desc', sort_menu: false, ...config };
     this._sortBy = this.config.sort_by;


### PR DESCRIPTION
## Summary
- make ranking card sorting controls easier to use on touchscreens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68812fdd49f4832ebc974d17c9a940c8