### PR TITLE
Fix double ranking reset button

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,13 @@ type: custom:tally-due-ranking-card
 
 The editor also allows defining a maximum width in pixels. The `sort_by` option lets you sort either alphabetically or by outstanding amount. With `sort_menu: true` a dropdown appears that allows changing the sort order directly.
 
+Administrators see a reset button in the bottom right that clears every user's tally. Set `show_reset: false` to hide this button even for admins.
+
 ```yaml
 type: custom:tally-due-ranking-card
 sort_by: name  # or due_desc (default) or due_asc
 sort_menu: true
+show_reset: false  # hide the admin reset button
 ```
 
 ## Acknowledgements

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "tally-list-card.js",
   "render_readme": true,
-  "version": "1.6.0"
+  "version": "1.7.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.6.0';
+const CARD_VERSION = '1.7.0';
 
 function fireEvent(node, type, detail = {}, options = {}) {
   node.dispatchEvent(

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,6 @@
 // Tally List Card
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.6.0';
+const CARD_VERSION = '1.7.0';
 
 window.customCards = window.customCards || [];
 window.customCards.push({
@@ -498,11 +498,26 @@ class TallyDueRankingCard extends LitElement {
         height: 32px;
         box-sizing: border-box;
       }
+      .reset-container {
+        text-align: right;
+        margin-top: 8px;
+      }
+      .reset-container button {
+        padding: 4px 8px;
+        background-color: red;
+        color: #fff;
+      }
     `,
   ];
 
   setConfig(config) {
-    this.config = { max_width: '', sort_by: 'due_desc', sort_menu: false, ...config };
+    this.config = {
+      max_width: '',
+      sort_by: 'due_desc',
+      sort_menu: false,
+      show_reset: true,
+      ...config,
+    };
     this._sortBy = this.config.sort_by;
     const width = this._normalizeWidth(this.config.max_width);
     if (width) {
@@ -573,6 +588,12 @@ class TallyDueRankingCard extends LitElement {
           </select>
         </div>`
       : '';
+    let resetButton = '';
+    if (isAdmin && this.config.show_reset !== false) {
+      resetButton = html`<div class="reset-container">
+        <button @click=${this._resetAllTallies}>Alle Striche zurücksetzen</button>
+      </div>`;
+    }
     return html`
       <ha-card style="${cardStyle}">
         ${sortMenu}
@@ -580,6 +601,7 @@ class TallyDueRankingCard extends LitElement {
           <thead><tr><th>#</th><th>Name</th><th>Zu zahlen</th></tr></thead>
           <tbody>${rows}</tbody>
         </table>
+        ${resetButton}
       </ha-card>
     `;
   }
@@ -698,6 +720,24 @@ class TallyDueRankingCard extends LitElement {
   _sortMenuChanged(ev) {
     this._sortBy = ev.target.value;
   }
+
+  _resetAllTallies() {
+    const input = prompt('Zum Zurücksetzen aller Striche "JA RESET" eingeben:');
+    if (input !== 'JA RESET') {
+      return;
+    }
+    const users = this.config.users || this._autoUsers || [];
+    for (const u of users) {
+      const buttonId = `button.${u.slug}_reset_tally`;
+      this.hass.callService('button', 'press', { entity_id: buttonId });
+      for (const entity of Object.values(u.drinks || {})) {
+        this.hass.callService('homeassistant', 'update_entity', { entity_id: entity });
+      }
+      if (u.amount_due_entity) {
+        this.hass.callService('homeassistant', 'update_entity', { entity_id: u.amount_due_entity });
+      }
+    }
+  }
 }
 
 customElements.define('tally-due-ranking-card', TallyDueRankingCard);
@@ -708,7 +748,13 @@ class TallyDueRankingCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { max_width: '', sort_by: 'due_desc', sort_menu: false, ...config };
+    this._config = {
+      max_width: '',
+      sort_by: 'due_desc',
+      sort_menu: false,
+      show_reset: true,
+      ...config,
+    };
   }
 
   render() {
@@ -742,6 +788,12 @@ class TallyDueRankingCardEditor extends LitElement {
           Sortiermenü anzeigen
         </label>
       </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.show_reset} @change=${this._resetChanged} />
+          Reset-Button anzeigen (nur Admins)
+        </label>
+      </div>
       <div class="version">Version: ${CARD_VERSION}</div>
     `;
   }
@@ -773,6 +825,17 @@ class TallyDueRankingCardEditor extends LitElement {
 
   _menuChanged(ev) {
     this._config = { ...this._config, sort_menu: ev.target.checked };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _resetChanged(ev) {
+    this._config = { ...this._config, show_reset: ev.target.checked };
     this.dispatchEvent(
       new CustomEvent('config-changed', {
         detail: { config: this._config },


### PR DESCRIPTION
## Summary
- ensure the ranking reset button is built once and placed below the table

## Testing
- `node --check tally-list-card.js`
- `node --check tally-list-card-editor.js`


------
https://chatgpt.com/codex/tasks/task_e_68813b7362bc832e8efb2420c31bc31b