### PR TITLE
Fix duplicate reset button

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -594,7 +594,6 @@ class TallyDueRankingCard extends LitElement {
     return html`
       <ha-card style="${cardStyle}">
         ${sortMenu}
-        ${resetButton}
         <table>
           <thead><tr><th>#</th><th>Name</th><th>Zu zahlen</th></tr></thead>
           <tbody>${rows}</tbody>


### PR DESCRIPTION
## Summary
- remove duplicate reset button from ranking card

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883a5776cb4832e86aa61d3c5c3e71c