### PR TITLE
Add total outstanding amount option in ranking card

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ type: custom:tally-due-ranking-card
 The editor also allows defining a maximum width in pixels. The `sort_by` option lets you sort either alphabetically or by outstanding amount. With `sort_menu: true` a dropdown appears that allows changing the sort order directly.
 
 Administrators see a reset button in the bottom right that clears every user's tally. Set `show_reset: false` to hide this button even for admins.
+The card also displays the combined outstanding amount for all users at the bottom. Use `show_total: false` to hide this summary.
 
 ```yaml
 type: custom:tally-due-ranking-card
 sort_by: name  # or due_desc (default) or due_asc
 sort_menu: true
 show_reset: false  # hide the admin reset button
+show_total: false  # hide the total amount row
 ```
 
 ## Acknowledgements

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "tally-list-card.js",
   "render_readme": true,
-  "version": "1.7.0"
+  "version": "1.8.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.7.0';
+const CARD_VERSION = '1.8.0';
 
 function fireEvent(node, type, detail = {}, options = {}) {
   node.dispatchEvent(

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,6 @@
 // Tally List Card
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.7.0';
+const CARD_VERSION = '1.8.0';
 
 window.customCards = window.customCards || [];
 window.customCards.push({
@@ -514,6 +514,7 @@ class TallyDueRankingCard extends LitElement {
       sort_by: 'due_desc',
       sort_menu: false,
       show_reset: true,
+      show_total: true,
       ...config,
     };
     this._sortBy = this.config.sort_by;
@@ -574,6 +575,10 @@ class TallyDueRankingCard extends LitElement {
       }
     });
     const rows = ranking.map((r, i) => html`<tr><td>${i + 1}</td><td>${r.name}</td><td>${r.due.toFixed(2)} €</td></tr>`);
+    const totalDue = ranking.reduce((sum, r) => sum + r.due, 0);
+    const totalRow = this.config.show_total !== false
+      ? html`<tfoot><tr><td colspan="2"><b>Gesamt</b></td><td>${totalDue.toFixed(2)} €</td></tr></tfoot>`
+      : '';
     const width = this._normalizeWidth(this.config.max_width);
     const cardStyle = width ? `max-width:${width};margin:0 auto;` : '';
     const sortMenu = this.config.sort_menu
@@ -597,6 +602,7 @@ class TallyDueRankingCard extends LitElement {
         <table>
           <thead><tr><th>#</th><th>Name</th><th>Zu zahlen</th></tr></thead>
           <tbody>${rows}</tbody>
+          ${totalRow}
         </table>
         ${resetButton}
       </ha-card>
@@ -622,7 +628,7 @@ class TallyDueRankingCard extends LitElement {
   }
 
   static getStubConfig() {
-    return { max_width: '', sort_by: 'due_desc', sort_menu: false };
+    return { max_width: '', sort_by: 'due_desc', sort_menu: false, show_total: true };
   }
   _gatherUsers() {
     const users = [];
@@ -750,6 +756,7 @@ class TallyDueRankingCardEditor extends LitElement {
       sort_by: 'due_desc',
       sort_menu: false,
       show_reset: true,
+      show_total: true,
       ...config,
     };
   }
@@ -789,6 +796,12 @@ class TallyDueRankingCardEditor extends LitElement {
         <label>
           <input type="checkbox" .checked=${this._config.show_reset} @change=${this._resetChanged} />
           Reset-Button anzeigen (nur Admins)
+        </label>
+      </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.show_total} @change=${this._totalChanged} />
+          Gesamtsumme anzeigen
         </label>
       </div>
       <div class="version">Version: ${CARD_VERSION}</div>
@@ -833,6 +846,17 @@ class TallyDueRankingCardEditor extends LitElement {
 
   _resetChanged(ev) {
     this._config = { ...this._config, show_reset: ev.target.checked };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _totalChanged(ev) {
+    this._config = { ...this._config, show_total: ev.target.checked };
     this.dispatchEvent(
       new CustomEvent('config-changed', {
         detail: { config: this._config },


### PR DESCRIPTION
## Summary
- allow showing the sum of all outstanding amounts in ranking card
- add checkbox in ranking card editor
- document new option in README
- bump version to 1.8.0

## Testing
- `node --check tally-list-card.js`
- `node --check tally-list-card-editor.js`


------
https://chatgpt.com/codex/tasks/task_e_6883afad893c832eaafdb6d8e6562c97