### PR TITLE
Update defaults for lock time and width

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ If the free amount equals **0 €**, the card hides the **Allowance** and **Am
 
 The card can now be configured directly in the Lovelace UI. It offers the following options:
 
-* **Lock time (ms)** – How long the buttons stay disabled after pressing **+1** or **-1**. The default is `1000` milliseconds.
-* **Maximum width (px)** – Optional width limit for the card in pixels. Enter a number and the `px` unit is added automatically. Useful when using panel views to prevent the layout from stretching too wide.
+* **Lock time (ms)** – How long the buttons stay disabled after pressing **+1** or **-1**. The default is `400` milliseconds.
+* **Maximum width (px)** – Optional width limit for the card in pixels. Enter a number and the `px` unit is added automatically. The default is `500` pixels. Useful when using panel views to prevent the layout from stretching too wide.
 * **Version** – Displays the installed card version.
 
 ## Amount Due Ranking

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -17,7 +17,7 @@ class TallyListCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 1000, max_width: '', ...config };
+    this._config = { lock_ms: 400, max_width: '500px', ...config };
   }
 
   render() {
@@ -45,7 +45,7 @@ class TallyListCardEditor extends LitElement {
 
   _lockChanged(ev) {
     const value = Number(ev.target.value);
-    this._config = { ...this._config, lock_ms: isNaN(value) ? 1000 : value };
+    this._config = { ...this._config, lock_ms: isNaN(value) ? 400 : value };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -31,7 +31,7 @@ class TallyListCard extends LitElement {
   selectedRemoveDrink = '';
 
   setConfig(config) {
-    this.config = { lock_ms: 1000, max_width: '', ...config };
+    this.config = { lock_ms: 400, max_width: '500px', ...config };
     this._disabled = false;
     const width = this._normalizeWidth(this.config.max_width);
     if (width) {
@@ -166,7 +166,7 @@ class TallyListCard extends LitElement {
     }
     this._disabled = true;
     this.requestUpdate();
-    const delay = Number(this.config.lock_ms ?? 1000);
+    const delay = Number(this.config.lock_ms ?? 400);
     setTimeout(() => {
       this._disabled = false;
       this.requestUpdate();
@@ -193,7 +193,7 @@ class TallyListCard extends LitElement {
     }
     this._disabled = true;
     this.requestUpdate();
-    const delay = Number(this.config.lock_ms ?? 1000);
+    const delay = Number(this.config.lock_ms ?? 400);
     setTimeout(() => {
       this._disabled = false;
       this.requestUpdate();
@@ -324,7 +324,7 @@ class TallyListCard extends LitElement {
   }
 
   static getStubConfig() {
-    return { lock_ms: 1000, max_width: '' };
+    return { lock_ms: 400, max_width: '500px' };
   }
 
   static styles = css`
@@ -400,7 +400,7 @@ class TallyListCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 1000, max_width: '', ...config };
+    this._config = { lock_ms: 400, max_width: '500px', ...config };
   }
 
   render() {
@@ -428,7 +428,7 @@ class TallyListCardEditor extends LitElement {
 
   _lockChanged(ev) {
     const value = Number(ev.target.value);
-    this._config = { ...this._config, lock_ms: isNaN(value) ? 1000 : value };
+    this._config = { ...this._config, lock_ms: isNaN(value) ? 400 : value };
     this.dispatchEvent(
       new CustomEvent('config-changed', {
         detail: { config: this._config },
@@ -510,7 +510,7 @@ class TallyDueRankingCard extends LitElement {
 
   setConfig(config) {
     this.config = {
-      max_width: '',
+      max_width: '500px',
       sort_by: 'due_desc',
       sort_menu: false,
       show_reset: true,
@@ -636,7 +636,7 @@ class TallyDueRankingCard extends LitElement {
   }
 
   static getStubConfig() {
-    return { max_width: '', sort_by: 'due_desc', sort_menu: false, show_total: true, max_entries: 0, hide_free: false };
+    return { max_width: '500px', sort_by: 'due_desc', sort_menu: false, show_total: true, max_entries: 0, hide_free: false };
   }
   _gatherUsers() {
     const users = [];
@@ -760,7 +760,7 @@ class TallyDueRankingCardEditor extends LitElement {
 
   setConfig(config) {
     this._config = {
-      max_width: '',
+      max_width: '500px',
       sort_by: 'due_desc',
       sort_menu: false,
       show_reset: true,


### PR DESCRIPTION
## Summary
- set default lock time to 400ms
- set default max width to 500px
- document the new defaults in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68849803323c832e8d0cbef23f65307b