### PR TITLE
Add option to hide remove drink menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The card can now be configured directly in the Lovelace UI. It offers the follow
 
 * **Lock time (ms)** – How long the buttons stay disabled after pressing **+1** or **-1**. The default is `400` milliseconds.
 * **Maximum width (px)** – Optional width limit for the card in pixels. Enter a number and the `px` unit is added automatically. The default is `500` pixels. Useful when using panel views to prevent the layout from stretching too wide.
+* **Show remove menu** – Toggle the dropdown for subtracting drinks. Enabled by default.
 * **Version** – Displays the installed card version.
 
 ## Amount Due Ranking

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -17,7 +17,7 @@ class TallyListCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 400, max_width: '500px', ...config };
+    this._config = { lock_ms: 400, max_width: '500px', show_remove: true, ...config };
   }
 
   render() {
@@ -39,6 +39,12 @@ class TallyListCardEditor extends LitElement {
           @input=${this._widthChanged}
         />
       </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.show_remove} @change=${this._removeChanged} />
+          Entfernen-Menü anzeigen
+        </label>
+      </div>
       <div class="version">Version: ${CARD_VERSION}</div>
     `;
   }
@@ -53,6 +59,11 @@ class TallyListCardEditor extends LitElement {
     const raw = ev.target.value.trim();
     const width = raw ? `${raw}px` : '';
     this._config = { ...this._config, max_width: width };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _removeChanged(ev) {
+    this._config = { ...this._config, show_remove: ev.target.checked };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -31,7 +31,7 @@ class TallyListCard extends LitElement {
   selectedRemoveDrink = '';
 
   setConfig(config) {
-    this.config = { lock_ms: 400, max_width: '500px', ...config };
+    this.config = { lock_ms: 400, max_width: '500px', show_remove: true, ...config };
     this._disabled = false;
     const width = this._normalizeWidth(this.config.max_width);
     if (width) {
@@ -149,14 +149,16 @@ class TallyListCard extends LitElement {
             ` : ''}
           </tfoot>
         </table>
-        <div class="remove-bottom">
-          <div class="remove-container">
-            <button @click=${() => this._removeDrink(this.selectedRemoveDrink)} ?disabled=${this._disabled}>-1</button>
-            <select @change=${this._selectRemoveDrink.bind(this)}>
-              ${drinks.map(d => html`<option value="${d}" ?selected=${d===this.selectedRemoveDrink}>${d.charAt(0).toUpperCase() + d.slice(1)}</option>`)}
-            </select>
+        ${this.config.show_remove !== false ? html`
+          <div class="remove-bottom">
+            <div class="remove-container">
+              <button @click=${() => this._removeDrink(this.selectedRemoveDrink)} ?disabled=${this._disabled}>-1</button>
+              <select @change=${this._selectRemoveDrink.bind(this)}>
+                ${drinks.map(d => html`<option value="${d}" ?selected=${d===this.selectedRemoveDrink}>${d.charAt(0).toUpperCase() + d.slice(1)}</option>`)}
+              </select>
+            </div>
           </div>
-        </div>
+        ` : ''}
       </ha-card>
     `;
   }
@@ -338,7 +340,7 @@ class TallyListCard extends LitElement {
   }
 
   static getStubConfig() {
-    return { lock_ms: 400, max_width: '500px' };
+    return { lock_ms: 400, max_width: '500px', show_remove: true };
   }
 
   static styles = css`
@@ -423,7 +425,7 @@ class TallyListCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 400, max_width: '500px', ...config };
+    this._config = { lock_ms: 400, max_width: '500px', show_remove: true, ...config };
   }
 
   render() {
@@ -445,6 +447,12 @@ class TallyListCardEditor extends LitElement {
           @input=${this._widthChanged}
         />
       </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.show_remove} @change=${this._removeChanged} />
+          Entfernen-Menü anzeigen
+        </label>
+      </div>
       <div class="version">Version: ${CARD_VERSION}</div>
     `;
   }
@@ -465,6 +473,17 @@ class TallyListCardEditor extends LitElement {
     const raw = ev.target.value.trim();
     const width = raw ? `${raw}px` : '';
     this._config = { ...this._config, max_width: width };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _removeChanged(ev) {
+    this._config = { ...this._config, show_remove: ev.target.checked };
     this.dispatchEvent(
       new CustomEvent('config-changed', {
         detail: { config: this._config },


### PR DESCRIPTION
## Summary
- add `show_remove` config option for TallyListCard
- support new option in editors
- document remove menu setting

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6884e27bc010832e8d935247449c50f7