### PR TITLE
Allow English reset confirmation

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -843,8 +843,9 @@ class TallyDueRankingCard extends LitElement {
   }
 
   _resetAllTallies() {
-    const input = prompt('Zum Zurücksetzen aller Striche "JA ICH WILL" eingeben:');
-    if (input !== 'JA ICH WILL') {
+    const input = prompt('Zum Zurücksetzen aller Striche "JA ICH WILL" bzw. "YES I WILL" eingeben:');
+    const normalized = (input || '').trim().toUpperCase();
+    if (normalized !== 'JA ICH WILL' && normalized !== 'YES I WILL') {
       return;
     }
     const users = this.config.users || this._autoUsers || [];


### PR DESCRIPTION
## Summary
- accept "YES I WILL" as confirmation for the admin reset prompt

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884ea8678ac832e92ac341966ddbdde