### PR TITLE
Enable tally editing for all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After the resource is available, open the Lovelace dashboard, click **Add Card**
 type: custom:tally-list-card
 ```
 
-The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required. Normal users can only select themselves, while admins may choose any person.
+The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required. Every user may now select any person.
 
 When a `person.<slug>` entity exists, its friendly name is used in the dropdown; otherwise the name comes from the tally sensors. Users are sorted alphabetically and the currently logged in user always appears first. The selected user's **display name** is sent to the `tally_list.add_drink` service, so capitalization is preserved. The card also matches the sensor slug against the person's friendly name, so mismatched slugs still detect the current user.
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -55,15 +55,7 @@ class TallyListCard extends LitElement {
     if (users.length === 0) {
       return html`<ha-card>Strichliste-Integration nicht gefunden. Bitte richte die Integration ein.</ha-card>`;
     }
-    const isAdmin = this.hass.user?.is_admin;
-    if (!isAdmin) {
-      const allowedSlugs = this._currentPersonSlugs();
-      const uid = this.hass.user?.id;
-      users = users.filter(u => u.user_id === uid || allowedSlugs.includes(u.slug));
-    }
-    if (users.length === 0) {
-      return html`<ha-card>Kein Zugriff auf Nutzer</ha-card>`;
-    }
+    // Allow all users to select any person
     const uid = this.hass.user?.id;
     const slugsOfUser = this._currentPersonSlugs();
     const own = users.find(u => u.user_id === uid || slugsOfUser.includes(u.slug));
@@ -587,14 +579,7 @@ class TallyDueRankingCard extends LitElement {
       return html`<ha-card>Strichliste-Integration nicht gefunden. Bitte richte die Integration ein.</ha-card>`;
     }
     const isAdmin = this.hass.user?.is_admin;
-    if (!isAdmin) {
-      const allowed = this._currentPersonSlugs();
-      const uid = this.hass.user?.id;
-      users = users.filter(u => u.user_id === uid || allowed.includes(u.slug));
-    }
-    if (users.length === 0) {
-      return html`<ha-card>Kein Zugriff auf Nutzer</ha-card>`;
-    }
+    // All users may see every person
     const prices = this.config.prices || this._autoPrices || {};
     const freeAmount = Number(this.config.free_amount ?? this._freeAmount ?? 0);
     let ranking = users.map(u => {
@@ -802,11 +787,7 @@ class TallyDueRankingCard extends LitElement {
   _copyRanking() {
     let users = this.config.users || this._autoUsers || [];
     const isAdmin = this.hass.user?.is_admin;
-    if (!isAdmin) {
-      const allowed = this._currentPersonSlugs();
-      const uid = this.hass.user?.id;
-      users = users.filter(u => u.user_id === uid || allowed.includes(u.slug));
-    }
+    // All users may copy the full ranking
     if (users.length === 0) return;
     const prices = this.config.prices || this._autoPrices || {};
     const freeAmount = Number(this.config.free_amount ?? this._freeAmount ?? 0);


### PR DESCRIPTION
## Summary
- allow normal users to select any person on the tally card
- same for the due ranking card and its copy action
- update README to describe the new behavior

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68891c6723cc832e83cc29ca098eaca3