### PR TITLE
Limit admin actions to configured list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After the resource is available, open the Lovelace dashboard, click **Add Card**
 type: custom:tally-list-card
 ```
 
-The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required. Normal users can only select themselves, while admins may choose any person.
+The dropdown lists all users detected from the integration and calculates totals using the stored price list. No manual configuration is required. Normal users can only select themselves, while admins registered via `ha_tally_list.get_admins` may choose any person.
 
 When a `person.<slug>` entity exists, its friendly name is used in the dropdown; otherwise the name comes from the tally sensors. Users are sorted alphabetically and the currently logged in user always appears first. The selected user's **display name** is sent to the `tally_list.add_drink` service, so capitalization is preserved. The card also matches the sensor slug against the person's friendly name, so mismatched slugs still detect the current user.
 
@@ -76,7 +76,7 @@ type: custom:tally-due-ranking-card
 
 The editor also allows defining a maximum width in pixels. The `sort_by` option lets you sort either alphabetically or by outstanding amount. With `sort_menu: true` a dropdown appears that allows changing the sort order directly.
 
-Administrators see a reset button in the bottom right that clears every user's tally. Set `show_reset: false` to hide this button even for admins.
+Administrators from the `ha_tally_list.get_admins` list see a reset button in the bottom right that clears every user's tally. Set `show_reset: false` to hide this button even for these admins.
 The card also displays the combined outstanding amount for all users at the bottom. Use `show_total: false` to hide this summary.
 With `max_entries` you can limit how many users are shown (0 means no limit). Enable `hide_free` to hide all users who do not owe anything.
 The list can be copied to the clipboard with a **Tabelle kopieren** button. Set `show_copy: false` to hide this button.
@@ -85,7 +85,7 @@ The list can be copied to the clipboard with a **Tabelle kopieren** button. Set 
 type: custom:tally-due-ranking-card
 sort_by: name  # or due_desc (default) or due_asc
 sort_menu: true
-show_reset: false  # hide the admin reset button
+show_reset: false  # hide the reset button even for Tally List admins
 show_total: false  # hide the total amount row
 max_entries: 5     # show only the top five users
 hide_free: true    # hide users with no outstanding amount

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -25,6 +25,7 @@ class TallyListCard extends LitElement {
     _autoPrices: { state: true },
     _freeAmount: { state: true },
     selectedRemoveDrink: { state: true },
+    _admins: { state: true },
     _disabled: { state: true },
   };
 
@@ -55,7 +56,7 @@ class TallyListCard extends LitElement {
     if (users.length === 0) {
       return html`<ha-card>Strichliste-Integration nicht gefunden. Bitte richte die Integration ein.</ha-card>`;
     }
-    const isAdmin = this.hass.user?.is_admin;
+    const isAdmin = this._isTallyAdmin();
     if (!isAdmin) {
       const allowedSlugs = this._currentPersonSlugs();
       const uid = this.hass.user?.id;
@@ -228,6 +229,9 @@ class TallyListCard extends LitElement {
 
   updated(changedProps) {
     if (changedProps.has('hass')) {
+      if (this._admins === undefined) {
+        this._fetchAdmins();
+      }
       if (!this.config.users) {
         this._autoUsers = this._gatherUsers();
       }
@@ -322,6 +326,25 @@ class TallyListCard extends LitElement {
     }
     return slugs;
   }
+
+  async _fetchAdmins() {
+    try {
+      const result = await this.hass.callWS({ type: 'ha_tally_list.get_admins' });
+      const admins = Array.isArray(result) ? result : result?.admins;
+      this._admins = Array.isArray(admins) ? admins : [];
+    } catch (e) {
+      this._admins = [];
+    }
+  }
+
+  _isTallyAdmin() {
+    const uid = this.hass.user?.id;
+    const slugs = this._currentPersonSlugs();
+    return (this._admins || []).some(a => a === uid || slugs.includes(a));
+  }
+
+
+
 
   _toNumber(value) {
     const num = Number(value);
@@ -520,6 +543,7 @@ class TallyDueRankingCard extends LitElement {
     _autoPrices: { state: true },
     _freeAmount: { state: true },
     _sortBy: { state: true },
+    _admins: { state: true },
   };
 
   static styles = [
@@ -586,7 +610,7 @@ class TallyDueRankingCard extends LitElement {
     if (users.length === 0) {
       return html`<ha-card>Strichliste-Integration nicht gefunden. Bitte richte die Integration ein.</ha-card>`;
     }
-    const isAdmin = this.hass.user?.is_admin;
+    const isAdmin = this._isTallyAdmin();
     if (!isAdmin) {
       const allowed = this._currentPersonSlugs();
       const uid = this.hass.user?.id;
@@ -673,6 +697,9 @@ class TallyDueRankingCard extends LitElement {
 
   updated(changedProps) {
     if (changedProps.has('hass')) {
+      if (this._admins === undefined) {
+        this._fetchAdmins();
+      }
       if (!this.config.users) {
         this._autoUsers = this._gatherUsers();
       }
@@ -783,6 +810,22 @@ class TallyDueRankingCard extends LitElement {
     return slugs;
   }
 
+  async _fetchAdmins() {
+    try {
+      const result = await this.hass.callWS({ type: 'ha_tally_list.get_admins' });
+      const admins = Array.isArray(result) ? result : result?.admins;
+      this._admins = Array.isArray(admins) ? admins : [];
+    } catch (e) {
+      this._admins = [];
+    }
+  }
+
+  _isTallyAdmin() {
+    const uid = this.hass.user?.id;
+    const slugs = this._currentPersonSlugs();
+    return (this._admins || []).some(a => a === uid || slugs.includes(a));
+  }
+
   _toNumber(value) {
     const num = Number(value);
     return isNaN(num) ? 0 : num;
@@ -801,7 +844,7 @@ class TallyDueRankingCard extends LitElement {
 
   _copyRanking() {
     let users = this.config.users || this._autoUsers || [];
-    const isAdmin = this.hass.user?.is_admin;
+    const isAdmin = this._isTallyAdmin();
     if (!isAdmin) {
       const allowed = this._currentPersonSlugs();
       const uid = this.hass.user?.id;


### PR DESCRIPTION
## Summary
- check admin rights against `ha_tally_list.get_admins`
- mention new behaviour in documentation

## Testing
- `node --check tally-list-card.js`
- `node --check tally-list-card-editor.js`


------
https://chatgpt.com/codex/tasks/task_e_68892f278708832e811980644f90b9b6