### PR TITLE
Add setting to limit admin view to own user

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The card can now be configured directly in the Lovelace UI. It offers the follow
 * **Lock time (ms)** – How long the buttons stay disabled after pressing **+1** or **-1**. The default is `400` milliseconds.
 * **Maximum width (px)** – Optional width limit for the card in pixels. Enter a number and the `px` unit is added automatically. The default is `500` pixels. Useful when using panel views to prevent the layout from stretching too wide.
 * **Show remove menu** – Toggle the dropdown for subtracting drinks. Enabled by default.
+* **Only show self** – Restrict the dropdown to the logged-in user even for admins.
 * **Version** – Displays the installed card version.
 
 ## Amount Due Ranking

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "tally-list-card.js",
   "render_readme": true,
-  "version": "1.9.0"
+  "version": "1.10.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.9.0';
+const CARD_VERSION = '1.10.0';
 
 function fireEvent(node, type, detail = {}, options = {}) {
   node.dispatchEvent(
@@ -17,7 +17,13 @@ class TallyListCardEditor extends LitElement {
   };
 
   setConfig(config) {
-    this._config = { lock_ms: 400, max_width: '500px', show_remove: true, ...config };
+    this._config = {
+      lock_ms: 400,
+      max_width: '500px',
+      show_remove: true,
+      only_self: false,
+      ...config,
+    };
   }
 
   render() {
@@ -45,6 +51,12 @@ class TallyListCardEditor extends LitElement {
           Entfernen-Menü anzeigen
         </label>
       </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.only_self} @change=${this._selfChanged} />
+          Nur eigenen Nutzer anzeigen (auch für Admins)
+        </label>
+      </div>
       <div class="version">Version: ${CARD_VERSION}</div>
     `;
   }
@@ -64,6 +76,11 @@ class TallyListCardEditor extends LitElement {
 
   _removeChanged(ev) {
     this._config = { ...this._config, show_remove: ev.target.checked };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _selfChanged(ev) {
+    this._config = { ...this._config, only_self: ev.target.checked };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,6 @@
 // Tally List Card
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.9.0';
+const CARD_VERSION = '1.10.0';
 
 window.customCards = window.customCards || [];
 window.customCards.push({
@@ -33,7 +33,13 @@ class TallyListCard extends LitElement {
   _tallyAdmins = [];
 
   setConfig(config) {
-    this.config = { lock_ms: 400, max_width: '500px', show_remove: true, ...config };
+    this.config = {
+      lock_ms: 400,
+      max_width: '500px',
+      show_remove: true,
+      only_self: false,
+      ...config,
+    };
     this._disabled = false;
     const width = this._normalizeWidth(this.config.max_width);
     if (width) {
@@ -58,7 +64,8 @@ class TallyListCard extends LitElement {
       return html`<ha-card>Strichliste-Integration nicht gefunden. Bitte richte die Integration ein.</ha-card>`;
     }
     const isAdmin = (this._tallyAdmins || []).includes(this.hass.user?.name);
-    if (!isAdmin) {
+    const limitSelf = (!isAdmin) || this.config.only_self;
+    if (limitSelf) {
       const allowedSlugs = this._currentPersonSlugs();
       const uid = this.hass.user?.id;
       users = users.filter(u => u.user_id === uid || allowedSlugs.includes(u.slug));
@@ -353,7 +360,7 @@ class TallyListCard extends LitElement {
   }
 
   static getStubConfig() {
-    return { lock_ms: 400, max_width: '500px', show_remove: true };
+    return { lock_ms: 400, max_width: '500px', show_remove: true, only_self: false };
   }
 
   static styles = css`


### PR DESCRIPTION
## Summary
- add `only_self` option to the main Tally Card so admins can view only themselves
- remove `only_self` from the ranking card and its editor

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `node --check tally-list-card.js`
- `node --check tally-list-card-editor.js`


------
https://chatgpt.com/codex/tasks/task_e_688bc13962f8832e915e85f4cfb0af50