### PR TITLE
Add debug menu and user override

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "tally-list-card.js",
   "render_readme": true,
-  "version": "1.10.0"
+  "version": "1.11.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.10.0';
+const CARD_VERSION = '1.11.0';
 
 function fireEvent(node, type, detail = {}, options = {}) {
   node.dispatchEvent(
@@ -22,6 +22,7 @@ class TallyListCardEditor extends LitElement {
       max_width: '500px',
       show_remove: true,
       only_self: false,
+      show_all_users: false,
       ...config,
     };
   }
@@ -57,7 +58,16 @@ class TallyListCardEditor extends LitElement {
           Trotz Admin nur eigenen Nutzer anzeigen
         </label>
       </div>
-      <div class="version">Version: ${CARD_VERSION}</div>
+      <details class="debug">
+        <summary>Debug</summary>
+        <div class="form">
+          <label>
+            <input type="checkbox" .checked=${this._config.show_all_users} @change=${this._debugAllChanged} />
+            Alle Nutzer anzeigen
+          </label>
+        </div>
+        <div class="version">Version: ${CARD_VERSION}</div>
+      </details>
     `;
   }
 
@@ -84,6 +94,11 @@ class TallyListCardEditor extends LitElement {
     fireEvent(this, 'config-changed', { config: this._config });
   }
 
+  _debugAllChanged(ev) {
+    this._config = { ...this._config, show_all_users: ev.target.checked };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
   static styles = css`
     .form {
       padding: 16px;
@@ -91,6 +106,14 @@ class TallyListCardEditor extends LitElement {
     input {
       width: 100%;
       box-sizing: border-box;
+    }
+    details.debug {
+      padding: 0 16px 16px;
+    }
+    details.debug summary {
+      cursor: pointer;
+      font-weight: bold;
+      outline: none;
     }
     .version {
       padding: 0 16px 16px;

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,6 @@
 // Tally List Card
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.10.0';
+const CARD_VERSION = '1.11.0';
 
 window.customCards = window.customCards || [];
 window.customCards.push({
@@ -38,6 +38,7 @@ class TallyListCard extends LitElement {
       max_width: '500px',
       show_remove: true,
       only_self: false,
+      show_all_users: false,
       ...config,
     };
     this._disabled = false;
@@ -64,7 +65,7 @@ class TallyListCard extends LitElement {
       return html`<ha-card>Strichliste-Integration nicht gefunden. Bitte richte die Integration ein.</ha-card>`;
     }
     const isAdmin = (this._tallyAdmins || []).includes(this.hass.user?.name);
-    const limitSelf = (!isAdmin) || this.config.only_self;
+    const limitSelf = (!isAdmin && !this.config.show_all_users) || this.config.only_self;
     if (limitSelf) {
       const allowedSlugs = this._currentPersonSlugs();
       const uid = this.hass.user?.id;
@@ -360,7 +361,13 @@ class TallyListCard extends LitElement {
   }
 
   static getStubConfig() {
-    return { lock_ms: 400, max_width: '500px', show_remove: true, only_self: false };
+    return {
+      lock_ms: 400,
+      max_width: '500px',
+      show_remove: true,
+      only_self: false,
+      show_all_users: false,
+    };
   }
 
   static styles = css`
@@ -485,7 +492,10 @@ class TallyListCardEditor extends LitElement {
           Nur eigenen Nutzer anzeigen (auch für Admins)
         </label>
       </div>
-      <div class="version">Version: ${CARD_VERSION}</div>
+      <details class="debug">
+        <summary>Debug</summary>
+        <div class="version">Version: ${CARD_VERSION}</div>
+      </details>
     `;
   }
 
@@ -1022,7 +1032,10 @@ class TallyDueRankingCardEditor extends LitElement {
           Personen ohne Betrag ausblenden
         </label>
       </div>
-      <div class="version">Version: ${CARD_VERSION}</div>
+      <details class="debug">
+        <summary>Debug</summary>
+        <div class="version">Version: ${CARD_VERSION}</div>
+      </details>
     `;
   }
 


### PR DESCRIPTION
## Summary
- add version 1.11.0
- introduce `show_all_users` option
- move version display into new Debug menus
- allow non‑admins to view all users when debug option enabled

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bc88c9a90832ea367b86a2982ff69