### PR TITLE
Remove white borders from colored buttons

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -411,6 +411,8 @@ class TallyListCard extends LitElement {
     .remove-container button {
       height: 32px;
       width: 32px;
+      border: none;
+      border-radius: 4px;
     }
     .remove-button {
       background-color: var(--error-color, #c62828);
@@ -426,6 +428,8 @@ class TallyListCard extends LitElement {
       width: 32px;
       background-color: var(--success-color, #2e7d32);
       color: white;
+      border: none;
+      border-radius: 4px;
     }
     table {
       width: 100%;
@@ -636,6 +640,8 @@ class TallyDueRankingCard extends LitElement {
         padding: 4px 8px;
         background-color: var(--error-color, #c62828);
         color: white;
+        border: none;
+        border-radius: 4px;
       }
       .copy-container {
         text-align: right;


### PR DESCRIPTION
## Summary
- Style add and remove buttons without default border and add rounded corners
- Style reset button without default border for cleaner look

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e39d2c4e8832e9127a0a53867775f