### PR TITLE
Format prices using Home Assistant locale

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -235,10 +235,10 @@ class TallyListCard extends LitElement {
         const isAvailable = stateObj && stateObj.state !== 'unavailable' && stateObj.state !== 'unknown';
         const count = this._toNumber(stateObj?.state);
         const price = this._toNumber(prices[drink]);
-        const priceStr = price.toFixed(2) + ` ${this._currency}`;
+        const priceStr = this._formatPrice(price) + ` ${this._currency}`;
         const cost = count * price;
         total += cost;
-        const costStr = cost.toFixed(2) + ` ${this._currency}`;
+        const costStr = this._formatPrice(cost) + ` ${this._currency}`;
         const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
         return html`<tr>
           <td><button class="add-button" @click=${() => this._addDrink(drink)} ?disabled=${this._disabled || !isAvailable}>+1</button></td>
@@ -259,8 +259,8 @@ class TallyListCard extends LitElement {
       this.selectedRemoveDrink = drinks[0] || '';
     }
 
-    const totalStr = total.toFixed(2) + ` ${this._currency}`;
-    const freeAmountStr = freeAmount.toFixed(2) + ` ${this._currency}`;
+    const totalStr = this._formatPrice(total) + ` ${this._currency}`;
+    const freeAmountStr = this._formatPrice(freeAmount) + ` ${this._currency}`;
     let due;
     if (user.amount_due_entity) {
       const dueState = this.hass.states[user.amount_due_entity];
@@ -269,7 +269,7 @@ class TallyListCard extends LitElement {
     } else {
       due = Math.max(total - freeAmount, 0);
     }
-    const dueStr = due.toFixed(2) + ` ${this._currency}`;
+    const dueStr = this._formatPrice(due) + ` ${this._currency}`;
     const width = this._normalizeWidth(this.config.max_width);
     const cardStyle = width ? `max-width:${width};margin:0 auto;` : '';
     return html`
@@ -499,6 +499,29 @@ class TallyListCard extends LitElement {
   _toNumber(value) {
     const num = Number(value);
     return isNaN(num) ? 0 : num;
+  }
+
+  _formatPrice(value) {
+    const locale = this.hass?.locale;
+    let locales;
+    switch (locale?.number_format) {
+      case 'comma_decimal':
+        locales = ['en-US', 'en'];
+        break;
+      case 'decimal_comma':
+        locales = ['de', 'es', 'it'];
+        break;
+      case 'space_comma':
+        locales = ['fr', 'sv', 'cs'];
+        break;
+      default:
+        locales =
+          locale?.language || this.hass?.language || navigator.language || 'en';
+    }
+    return new Intl.NumberFormat(locales, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
   }
 
   _normalizeWidth(value) {
@@ -926,10 +949,10 @@ class TallyDueRankingCard extends LitElement {
     if (this.config.max_entries > 0) {
       ranking = ranking.slice(0, this.config.max_entries);
     }
-    const rows = ranking.map((r, i) => html`<tr><td>${i + 1}</td><td>${r.name}</td><td>${r.due.toFixed(2)} ${this._currency}</td></tr>`);
+    const rows = ranking.map((r, i) => html`<tr><td>${i + 1}</td><td>${r.name}</td><td>${this._formatPrice(r.due)} ${this._currency}</td></tr>`);
     const totalDue = ranking.reduce((sum, r) => sum + r.due, 0);
     const totalRow = this.config.show_total !== false
-      ? html`<tfoot><tr><td colspan="2"><b>${this._t('total')}</b></td><td>${totalDue.toFixed(2)} ${this._currency}</td></tr></tfoot>`
+      ? html`<tfoot><tr><td colspan="2"><b>${this._t('total')}</b></td><td>${this._formatPrice(totalDue)} ${this._currency}</td></tr></tfoot>`
       : '';
     const width = this._normalizeWidth(this.config.max_width);
     const cardStyle = width ? `max-width:${width};margin:0 auto;` : '';
@@ -1112,6 +1135,29 @@ class TallyDueRankingCard extends LitElement {
     return isNaN(num) ? 0 : num;
   }
 
+  _formatPrice(value) {
+    const locale = this.hass?.locale;
+    let locales;
+    switch (locale?.number_format) {
+      case 'comma_decimal':
+        locales = ['en-US', 'en'];
+        break;
+      case 'decimal_comma':
+        locales = ['de', 'es', 'it'];
+        break;
+      case 'space_comma':
+        locales = ['fr', 'sv', 'cs'];
+        break;
+      default:
+        locales =
+          locale?.language || this.hass?.language || navigator.language || 'en';
+    }
+    return new Intl.NumberFormat(locales, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+
   _normalizeWidth(value) {
     if (!value && value !== 0) return '';
     const str = String(value).trim();
@@ -1170,10 +1216,10 @@ class TallyDueRankingCard extends LitElement {
     if (this.config.max_entries > 0) {
       ranking = ranking.slice(0, this.config.max_entries);
     }
-    const lines = ranking.map((r, i) => `${i + 1}. ${r.name}: ${r.due.toFixed(2)} ${this._currency}`);
+    const lines = ranking.map((r, i) => `${i + 1}. ${r.name}: ${this._formatPrice(r.due)} ${this._currency}`);
     if (this.config.show_total !== false) {
       const total = ranking.reduce((sum, r) => sum + r.due, 0);
-      lines.push(`${this._t('total')}: ${total.toFixed(2)} ${this._currency}`);
+      lines.push(`${this._t('total')}: ${this._formatPrice(total)} ${this._currency}`);
     }
     navigator.clipboard.writeText(lines.join('\n')).then(() => {
       this.dispatchEvent(


### PR DESCRIPTION
## Summary
- format item prices, totals, and rankings using locale-aware decimals
- add `_formatPrice` helper leveraging `hass.locale.number_format`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e490db878832e9260b2a5192f56cb