### PR TITLE
feat: add options to hide free amount and amount due

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ data:
 
 If `sensor.preisliste_free_amount` exists, its value is deducted from every user's total. The table displays this free amount and shows the final **Amount due** sum. When sensors named `sensor.<name>_amount_due` are present, their values are used directly for the **Amount due** row instead of calculating it from the drink counts.
 
-If the free amount equals **0 €**, the card hides the **Allowance** and **Amount due** rows and only shows the **Total** line.
+If the free amount equals **0 €**, the card hides the **Allowance** and **Amount due** rows and only shows the **Total** line. You can also hide these rows explicitly with `show_free_amount: false` or `show_amount_due: false`.
 
 ## UI configuration
 
@@ -66,6 +66,8 @@ The card can now be configured directly in the Lovelace UI. It offers the follow
 * **Lock time (ms)** – How long the buttons stay disabled after pressing **+1** or **-1**. The default is `400` milliseconds.
 * **Maximum width (px)** – Optional width limit for the card in pixels. Enter a number and the `px` unit is added automatically. The default is `500` pixels. Useful when using panel views to prevent the layout from stretching too wide.
 * **Show remove menu** – Toggle the dropdown for subtracting drinks. Enabled by default.
+* **Show free amount** – Toggle the deduction row for the free amount. Enabled by default.
+* **Show amount due** – Toggle the final amount due row. Enabled by default.
 * **Only show self** – Restrict the dropdown to the logged-in user even for admins.
 * **Language** – Override the detected language with **Auto**, **Deutsch** or **English**.
 * **Version** – Displays the installed card version.

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "tally-list-card.js",
   "render_readme": true,
-  "version": "1.11.0"
+  "version": "1.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,11 +1,13 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.11.0';
+const CARD_VERSION = '1.12.0';
 
 const TL_STRINGS = {
   en: {
     lock_ms: 'Lock duration (ms)',
     max_width: 'Maximum width (px)',
     show_remove_menu: 'Show remove menu',
+    show_free_amount: 'Show free amount',
+    show_amount_due: 'Show amount due',
     only_self: 'Only show own user even for admins',
     show_all_users: 'Show all users',
     debug: 'Debug',
@@ -19,6 +21,8 @@ const TL_STRINGS = {
     lock_ms: 'Sperrzeit (ms)',
     max_width: 'Maximale Breite (px)',
     show_remove_menu: 'Entfernen-Menü anzeigen',
+    show_free_amount: 'Freibetrag anzeigen',
+    show_amount_due: 'Zu zahlenden Betrag anzeigen',
     only_self: 'Trotz Admin nur eigenen Nutzer anzeigen',
     show_all_users: 'Alle Nutzer anzeigen',
     debug: 'Debug',
@@ -62,6 +66,8 @@ class TallyListCardEditor extends LitElement {
       lock_ms: 400,
       max_width: '500px',
       show_remove: true,
+      show_free_amount: true,
+      show_amount_due: true,
       only_self: false,
       show_all_users: false,
       language: 'auto',
@@ -96,6 +102,18 @@ class TallyListCardEditor extends LitElement {
         <label>
           <input type="checkbox" .checked=${this._config.show_remove} @change=${this._removeChanged} />
           ${this._t('show_remove_menu')}
+        </label>
+      </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.show_free_amount} @change=${this._freeChanged} />
+          ${this._t('show_free_amount')}
+        </label>
+      </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.show_amount_due} @change=${this._dueChanged} />
+          ${this._t('show_amount_due')}
         </label>
       </div>
       <div class="form">
@@ -140,6 +158,16 @@ class TallyListCardEditor extends LitElement {
 
   _removeChanged(ev) {
     this._config = { ...this._config, show_remove: ev.target.checked };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _freeChanged(ev) {
+    this._config = { ...this._config, show_free_amount: ev.target.checked };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _dueChanged(ev) {
+    this._config = { ...this._config, show_amount_due: ev.target.checked };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,6 @@
 // Tally List Card
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.11.0';
+const CARD_VERSION = '1.12.0';
 
 const TL_STRINGS = {
   en: {
@@ -23,6 +23,8 @@ const TL_STRINGS = {
     lock_ms: 'Lock duration (ms)',
     max_width: 'Maximum width (px)',
     show_remove_menu: 'Show remove menu',
+    show_free_amount: 'Show free amount',
+    show_amount_due: 'Show amount due',
     only_self: 'Only show own user even for admins',
     show_all_users: 'Show all users',
     debug: 'Debug',
@@ -69,6 +71,8 @@ const TL_STRINGS = {
     lock_ms: 'Sperrzeit (ms)',
     max_width: 'Maximale Breite (px)',
     show_remove_menu: 'Entfernen-Menü anzeigen',
+    show_free_amount: 'Freibetrag anzeigen',
+    show_amount_due: 'Zu zahlenden Betrag anzeigen',
     only_self: 'Trotz Admin nur eigenen Nutzer anzeigen',
     show_all_users: 'Alle Nutzer anzeigen',
     debug: 'Debug',
@@ -169,6 +173,8 @@ class TallyListCard extends LitElement {
       show_remove: true,
       only_self: false,
       show_all_users: false,
+      show_free_amount: true,
+      show_amount_due: true,
       language: 'auto',
       ...config,
     };
@@ -270,6 +276,8 @@ class TallyListCard extends LitElement {
       due = Math.max(total - freeAmount, 0);
     }
     const dueStr = this._formatPrice(due) + ` ${this._currency}`;
+    const showFree = freeAmount > 0 && this.config.show_free_amount !== false;
+    const showDue = freeAmount > 0 && this.config.show_amount_due !== false;
     const width = this._normalizeWidth(this.config.max_width);
     const cardStyle = width ? `max-width:${width};margin:0 auto;` : '';
     return html`
@@ -287,10 +295,12 @@ class TallyListCard extends LitElement {
           <tbody>${rows}</tbody>
           <tfoot>
             <tr><td colspan="4"><b>${this._t('total')}</b></td><td>${totalStr}</td></tr>
-            ${freeAmount > 0 ? html`
-              <tr><td colspan="4"><b>${this._t('free_amount')}</b></td><td>- ${freeAmountStr}</td></tr>
-              <tr><td colspan="4"><b>${this._t('amount_due')}</b></td><td>${dueStr}</td></tr>
-            ` : ''}
+            ${showFree
+              ? html`<tr><td colspan="4"><b>${this._t('free_amount')}</b></td><td>- ${freeAmountStr}</td></tr>`
+              : ''}
+            ${showDue
+              ? html`<tr><td colspan="4"><b>${this._t('amount_due')}</b></td><td>${dueStr}</td></tr>`
+              : ''}
           </tfoot>
         </table>
         ${this.config.show_remove !== false ? html`
@@ -542,6 +552,8 @@ class TallyListCard extends LitElement {
       show_remove: true,
       only_self: false,
       show_all_users: false,
+      show_free_amount: true,
+      show_amount_due: true,
     };
   }
 
@@ -643,6 +655,8 @@ class TallyListCardEditor extends LitElement {
       show_remove: true,
       only_self: false,
       show_all_users: false,
+      show_free_amount: true,
+      show_amount_due: true,
       language: 'auto',
       ...config,
     };
@@ -675,6 +689,18 @@ class TallyListCardEditor extends LitElement {
         <label>
           <input type="checkbox" .checked=${this._config.show_remove} @change=${this._removeChanged} />
           ${this._t('show_remove_menu')}
+        </label>
+      </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.show_free_amount} @change=${this._freeChanged} />
+          ${this._t('show_free_amount')}
+        </label>
+      </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.show_amount_due} @change=${this._dueChanged} />
+          ${this._t('show_amount_due')}
         </label>
       </div>
       <div class="form">
@@ -731,6 +757,28 @@ class TallyListCardEditor extends LitElement {
 
   _removeChanged(ev) {
     this._config = { ...this._config, show_remove: ev.target.checked };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _freeChanged(ev) {
+    this._config = { ...this._config, show_free_amount: ev.target.checked };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _dueChanged(ev) {
+    this._config = { ...this._config, show_amount_due: ev.target.checked };
     this.dispatchEvent(
       new CustomEvent('config-changed', {
         detail: { config: this._config },


### PR DESCRIPTION
## Summary
- add `show_free_amount` and `show_amount_due` options for tally list card
- allow hiding allowance and amount-due rows
- bump version to 1.12.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f55c5283c832ea6a63d73e7420c92