### PR TITLE
Disable remove button when selected drink count is zero

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": true,
   "filename": "tally-list-card.js",
   "render_readme": true,
-  "version": "1.11.0"
+  "version": "1.11.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.11.0';
+const CARD_VERSION = '1.11.1';
 
 const TL_STRINGS = {
   en: {

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,6 @@
 // Tally List Card
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.11.0';
+const CARD_VERSION = '1.11.1';
 
 const TL_STRINGS = {
   en: {
@@ -259,6 +259,10 @@ class TallyListCard extends LitElement {
       this.selectedRemoveDrink = drinks[0] || '';
     }
 
+    const removeCount = this.selectedRemoveDrink
+      ? this._toNumber(this.hass.states[user.drinks[this.selectedRemoveDrink]]?.state)
+      : 0;
+
     const totalStr = this._formatPrice(total) + ` ${this._currency}`;
     const freeAmountStr = this._formatPrice(freeAmount) + ` ${this._currency}`;
     let due;
@@ -293,7 +297,7 @@ class TallyListCard extends LitElement {
             ` : ''}
             ${this.config.show_remove !== false ? html`
               <tr class="remove-row">
-                <td><button class="remove-button" @click=${() => this._removeDrink(this.selectedRemoveDrink)} ?disabled=${this._disabled}>-1</button></td>
+                <td><button class="remove-button" @click=${() => this._removeDrink(this.selectedRemoveDrink)} ?disabled=${this._disabled || removeCount <= 0}>-1</button></td>
                 <td colspan="4" class="remove-select-cell">
                   <select class="remove-select" @change=${this._selectRemoveDrink.bind(this)}>
                     ${drinks.map(d => html`<option value="${d}" ?selected=${d===this.selectedRemoveDrink}>${d.charAt(0).toUpperCase() + d.slice(1)}</option>`)}


### PR DESCRIPTION
## Summary
- disable remove button when the selected drink's count is 0
- bump card version to 1.11.1

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f63abca30832e94d1380bdb2142e8