### PR TITLE
Disable remove button when drinks depleted

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -259,6 +259,16 @@ class TallyListCard extends LitElement {
       this.selectedRemoveDrink = drinks[0] || '';
     }
 
+    const selectedEntity = user.drinks[this.selectedRemoveDrink];
+    const selectedState = selectedEntity ? this.hass.states[selectedEntity] : null;
+    const selectedAvailable =
+      selectedState &&
+      selectedState.state !== 'unavailable' &&
+      selectedState.state !== 'unknown';
+    const selectedCount = this._toNumber(selectedState?.state);
+    const removeDisabled =
+      this._disabled || !selectedAvailable || selectedCount <= 0;
+
     const totalStr = this._formatPrice(total) + ` ${this._currency}`;
     const freeAmountStr = this._formatPrice(freeAmount) + ` ${this._currency}`;
     let due;
@@ -293,7 +303,7 @@ class TallyListCard extends LitElement {
             ` : ''}
             ${this.config.show_remove !== false ? html`
               <tr class="remove-row">
-                <td><button class="remove-button" @click=${() => this._removeDrink(this.selectedRemoveDrink)} ?disabled=${this._disabled}>-1</button></td>
+                <td><button class="remove-button" @click=${() => this._removeDrink(this.selectedRemoveDrink)} ?disabled=${removeDisabled}>-1</button></td>
                 <td colspan="4" class="remove-select-cell">
                   <select class="remove-select" @change=${this._selectRemoveDrink.bind(this)}>
                     ${drinks.map(d => html`<option value="${d}" ?selected=${d===this.selectedRemoveDrink}>${d.charAt(0).toUpperCase() + d.slice(1)}</option>`)}
@@ -346,6 +356,20 @@ class TallyListCard extends LitElement {
     if (this._disabled || !drink) {
       return;
     }
+
+    const users = this.config.users || this._autoUsers || [];
+    const user = users.find(u => (u.name || u.slug) === this.selectedUser);
+    const entity = user?.drinks?.[drink];
+    const stateObj = entity ? this.hass.states[entity] : null;
+    const isAvailable =
+      stateObj &&
+      stateObj.state !== 'unavailable' &&
+      stateObj.state !== 'unknown';
+    const count = this._toNumber(stateObj?.state);
+    if (!isAvailable || count <= 0) {
+      return;
+    }
+
     this._disabled = true;
     this.requestUpdate();
     const delay = Number(this.config.lock_ms ?? 400);
@@ -360,9 +384,6 @@ class TallyListCard extends LitElement {
       drink: displayDrink,
     });
 
-    const users = this.config.users || this._autoUsers || [];
-    const user = users.find(u => (u.name || u.slug) === this.selectedUser);
-    const entity = user?.drinks?.[drink];
     if (entity) {
       this.hass.callService('homeassistant', 'update_entity', {
         entity_id: entity,


### PR DESCRIPTION
## Summary
- Disable `-1` button when selected drink has no remaining count
- Prevent service calls when attempting to remove unavailable or zero-count drinks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890e5a70fd8832ebeb1c150606d022e