### PR TITLE
docs: mention integration requirement

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -4,6 +4,8 @@
 
 Eine Lovelace-Karte für Home Assistant, die Getränkezähler pro Nutzer anzeigt und aktualisieren lässt. Nach der Auswahl eines Namens erscheinen die Anzahl der Getränke sowie der fällige Betrag. Nutzer und Preise werden automatisch aus der Tally‑List‑Integration gelesen. Währung und Sprache folgen den Home‑Assistant‑Einstellungen (Englisch und Deutsch, manuelle Auswahl möglich).
 
+**Hinweis:** Für diese Karte wird die [Tally‑List‑Integration](https://github.com/Spider19996/ha-tally-list) benötigt.
+
 ![Screenshot der Tally List Karte](images/image1.png)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A Lovelace card for Home Assistant that displays drink tallies per user and allows updating them. Selecting a name shows drink counts and the amount owed. Prices and users are read automatically from the Tally List integration. Currency and language follow Home Assistant settings (English and German supported, with optional override).
 
+**Note:** This card requires the [Tally List integration](https://github.com/Spider19996/ha-tally-list).
+
 ![Screenshot of the Tally List Card](images/image1.png)
 
 ## Installation


### PR DESCRIPTION
## Summary
- Clarify that the Lovelace card requires the Tally List integration to function
- Mirror integration requirement note in German documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68932831bf80832ea96cbff0bbc6e6c0