### PR TITLE
Use English names for price list sensors

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -32,7 +32,7 @@ Nach dem Hinzufügen der Ressource das Dashboard öffnen, **Karte hinzufügen** 
 ```yaml
 type: custom:tally-list-card
 ```
-Alle von der Integration erkannten Nutzer erscheinen in der Auswahlliste. Administratoren (laut Tally‑List‑Integration) können jeden Nutzer wählen, normale Nutzer nur sich selbst. Getränkepreise stammen aus Sensoren `sensor.preisliste_<getränk>_price`. Falls `sensor.preisliste_free_amount` existiert, wird dieser Betrag jedem Nutzer gutgeschrieben. Sensoren `sensor.<name>_amount_due` überschreiben den berechneten Betrag.
+Alle von der Integration erkannten Nutzer erscheinen in der Auswahlliste. Administratoren (laut Tally‑List‑Integration) können jeden Nutzer wählen, normale Nutzer nur sich selbst. Getränkepreise stammen aus Sensoren `sensor.price_list_<getränk>_price`. Falls `sensor.price_list_free_amount` existiert, wird dieser Betrag jedem Nutzer gutgeschrieben. Sensoren `sensor.<name>_amount_due` überschreiben den berechneten Betrag.
 
 Ein Klick auf **+1** fügt ein Getränk hinzu:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ After the resource is available, open the dashboard, choose **Add Card**, and se
 ```yaml
 type: custom:tally-list-card
 ```
-All users detected by the integration appear in the dropdown. Admins (as defined in the Tally List integration) may choose any user; regular users can only select themselves. Drink prices are taken from sensors named `sensor.preisliste_<drink>_price`. If `sensor.preisliste_free_amount` exists, its value is deducted from each user's total. Sensors named `sensor.<name>_amount_due` override the calculated amount due.
+All users detected by the integration appear in the dropdown. Admins (as defined in the Tally List integration) may choose any user; regular users can only select themselves. Drink prices are taken from sensors named `sensor.price_list_<drink>_price`. If `sensor.price_list_free_amount` exists, its value is deducted from each user's total. Sensors named `sensor.<name>_amount_due` override the calculated amount due.
 
 Pressing **+1** adds a drink:
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -481,7 +481,7 @@ class TallyListCard extends LitElement {
     const prices = {};
     const states = this.hass.states;
     for (const [entity, state] of Object.entries(states)) {
-      const match = entity.match(/^sensor\.preisliste_([^_]+)_price$/);
+      const match = entity.match(/^sensor\.price_list_([^_]+)_price$/);
       if (match) {
         const drink = match[1];
         const price = parseFloat(state.state);
@@ -496,7 +496,7 @@ class TallyListCard extends LitElement {
   }
 
   _gatherFreeAmount() {
-    const state = this.hass.states['sensor.preisliste_free_amount'];
+    const state = this.hass.states['sensor.price_list_free_amount'];
     if (!state) return 0;
     const val = parseFloat(state.state);
     return isNaN(val) ? 0 : val;
@@ -1113,7 +1113,7 @@ class TallyDueRankingCard extends LitElement {
     const prices = {};
     const states = this.hass.states;
     for (const [entity, state] of Object.entries(states)) {
-      const match = entity.match(/^sensor\.preisliste_([^_]+)_price$/);
+      const match = entity.match(/^sensor\.price_list_([^_]+)_price$/);
       if (match) {
         const drink = match[1];
         const price = parseFloat(state.state);
@@ -1128,7 +1128,7 @@ class TallyDueRankingCard extends LitElement {
   }
 
   _gatherFreeAmount() {
-    const state = this.hass.states['sensor.preisliste_free_amount'];
+    const state = this.hass.states['sensor.price_list_free_amount'];
     if (!state) return 0;
     const val = parseFloat(state.state);
     return isNaN(val) ? 0 : val;


### PR DESCRIPTION
## Summary
- recognize price list sensors using `sensor.price_list_*` naming
- document new price list sensor names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689377cd000c832ebf035464cf06a62a