### PR TITLE
feat(ranking): show all users without admin

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -58,7 +58,7 @@ Folgende Optionen stehen im UI zur Verfügung:
 
 ## Betrag-Rangliste
 
-Eine zweite Karte listet alle Nutzer nach offenem Betrag sortiert auf.
+Eine zweite Karte listet alle Nutzer nach offenem Betrag sortiert auf. Die offenen Beträge sind für alle Nutzer sichtbar; Adminrechte werden nur für den Reset-Button benötigt.
 
 ```yaml
 type: custom:tally-due-ranking-card

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The card offers the following options in the UI:
 
 ## Amount Due Ranking
 
-A second card lists all users ordered by outstanding amount.
+A second card lists all users ordered by outstanding amount. Outstanding balances are visible to all users; admin rights are only required for the reset button.
 
 ```yaml
 type: custom:tally-due-ranking-card

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -552,7 +552,7 @@ class TallyListCard extends LitElement {
     }
     return slugs;
   }
-  
+
   _toNumber(value) {
     const num = Number(value);
     return isNaN(num) ? 0 : num;
@@ -959,14 +959,6 @@ class TallyDueRankingCard extends LitElement {
     }
     const userNames = [this.hass.user?.name, ...this._currentPersonNames()];
     const isAdmin = userNames.some(n => (this._tallyAdmins || []).includes(n));
-    if (!isAdmin) {
-      const allowed = this._currentPersonSlugs();
-      const uid = this.hass.user?.id;
-      users = users.filter(u => u.user_id === uid || allowed.includes(u.slug));
-    }
-    if (users.length === 0) {
-      return html`<ha-card>${this._t('no_user_access')}</ha-card>`;
-    }
     const prices = this.config.prices || this._autoPrices || {};
     const freeAmount = Number(this.config.free_amount ?? this._freeAmount ?? 0);
     let ranking = users.map(u => {
@@ -1168,22 +1160,6 @@ class TallyDueRankingCard extends LitElement {
     return names;
   }
 
-  _currentPersonSlugs() {
-    const userId = this.hass.user?.id;
-    if (!userId) return [];
-    const slugs = [];
-    for (const [entity, state] of Object.entries(this.hass.states)) {
-      if (entity.startsWith('person.') && state.attributes.user_id === userId) {
-        const slug = entity.substring('person.'.length);
-        slugs.push(slug);
-        const alt = this._slugify(state.attributes.friendly_name || '');
-        if (alt && alt !== slug) {
-          slugs.push(alt);
-        }
-      }
-    }
-    return slugs;
-  }
 
   _toNumber(value) {
     const num = Number(value);
@@ -1225,14 +1201,7 @@ class TallyDueRankingCard extends LitElement {
   }
 
   _copyRanking() {
-    let users = this.config.users || this._autoUsers || [];
-    const userNames = [this.hass.user?.name, ...this._currentPersonNames()];
-    const isAdmin = userNames.some(n => (this._tallyAdmins || []).includes(n));
-    if (!isAdmin) {
-      const allowed = this._currentPersonSlugs();
-      const uid = this.hass.user?.id;
-      users = users.filter(u => u.user_id === uid || allowed.includes(u.slug));
-    }
+    const users = this.config.users || this._autoUsers || [];
     if (users.length === 0) return;
     const prices = this.config.prices || this._autoPrices || {};
     const freeAmount = Number(this.config.free_amount ?? this._freeAmount ?? 0);


### PR DESCRIPTION
## Summary
- allow non-admin users to see all dues in ranking card
- copy ranking works without admin privileges
- document that viewing all balances doesn't require admin rights

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689383235ff0832e9c04e259f0c85603