### PR TITLE
chore: bump version to v06.08.2025

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "1.11.1",
+  "version": "v06.08.2025",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.11.1';
+const CARD_VERSION = 'v06.08.2025';
 
 const TL_STRINGS = {
   en: {

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,6 @@
 // Tally List Card
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = '1.11.1';
+const CARD_VERSION = 'v06.08.2025';
 
 const TL_STRINGS = {
   en: {


### PR DESCRIPTION
## Summary
- bump version to v06.08.2025 across package and card constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893b9841998832eb1c622e31906e29d