### PR TITLE
feat: redesign tally card editor and button styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "ha-tally-list-lovelace",
+  "version": "v08.08.2025",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ha-tally-list-lovelace",
+      "version": "v08.08.2025"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "v06.08.2025",
+  "version": "v08.08.2025",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = 'v06.08.2025';
+const CARD_VERSION = '08.08.2025';
 
 const TL_STRINGS = {
   en: {
@@ -15,6 +15,16 @@ const TL_STRINGS = {
     german: 'German',
     english: 'English',
     version: 'Version',
+    general: 'General',
+    user_selection: 'User selection',
+    tabs_section: 'Tabs',
+    grid_section: 'Grid',
+    labels_section: 'Labels',
+    accessibility: 'Accessibility',
+    title: 'Title',
+    currency_override: 'Currency override',
+    tab_all_label_label: '"All" tab label',
+    tab_misc_label_label: '"#" tab label',
     user_selector: 'User selector',
     user_selector_list: 'List',
     user_selector_tabs: 'Tabs',
@@ -47,6 +57,16 @@ const TL_STRINGS = {
     german: 'Deutsch',
     english: 'Englisch',
     version: 'Version',
+    general: 'Allgemein',
+    user_selection: 'Nutzerauswahl',
+    tabs_section: 'Tabs',
+    grid_section: 'Grid',
+    labels_section: 'Beschriftungen',
+    accessibility: 'Barrierefreiheit',
+    title: 'Titel',
+    currency_override: 'Währung überschreiben',
+    tab_all_label_label: 'Tab "Alle" Beschriftung',
+    tab_misc_label_label: 'Tab "#" Beschriftung',
     user_selector: 'Nutzerauswahl',
     user_selector_list: 'Liste',
     user_selector_tabs: 'Tabs',
@@ -113,6 +133,11 @@ class TallyListCardEditor extends LitElement {
       wrap_labels: false,
       ...(config?.grid || {}),
     };
+    const i18n = {
+      tab_all_label: 'All',
+      tab_misc_label: '#',
+      ...(config?.i18n || {}),
+    };
     this._config = {
       lock_ms: 400,
       max_width: '500px',
@@ -123,9 +148,12 @@ class TallyListCardEditor extends LitElement {
       language: 'auto',
       user_selector: 'list',
       focus_outline: true,
+      title: '',
+      currency_override: '',
       ...config,
       tabs,
       grid,
+      i18n,
     };
   }
 
@@ -135,68 +163,71 @@ class TallyListCardEditor extends LitElement {
 
   render() {
     if (!this._config) return html``;
+    const showTabs = this._config.user_selector === 'tabs';
+    const showGrid = ['tabs', 'grid'].includes(this._config.user_selector);
     return html`
-      <div class="form">
-        <label>${this._t('lock_ms')}</label>
-        <input
-          type="number"
-          .value=${this._config.lock_ms}
-          @input=${this._lockChanged}
-        />
-      </div>
-      <div class="form">
-        <label>${this._t('max_width')}</label>
-        <input
-          type="number"
-          .value=${(this._config.max_width ?? '').replace(/px$/, '')}
-          @input=${this._widthChanged}
-        />
-      </div>
-      <div class="form">
-        <label>
-          <input type="checkbox" .checked=${this._config.show_remove} @change=${this._removeChanged} />
-          ${this._t('show_remove_menu')}
-        </label>
-      </div>
-      <div class="form">
-        <label>
-          <input type="checkbox" .checked=${this._config.only_self} @change=${this._selfChanged} />
-          ${this._t('only_self')}
-        </label>
-      </div>
-      <div class="form">
-        <label>${this._t('user_selector')}</label>
-        <select @change=${this._userSelectorChanged}>
-          <option value="list" ?selected=${this._config.user_selector === 'list'}>${this._t('user_selector_list')}</option>
-          <option value="tabs" ?selected=${this._config.user_selector === 'tabs'}>${this._t('user_selector_tabs')}</option>
-          <option value="grid" ?selected=${this._config.user_selector === 'grid'}>${this._t('user_selector_grid')}</option>
-        </select>
-      </div>
-      ${['tabs', 'grid'].includes(this._config.user_selector)
-        ? html`
-            ${this._config.user_selector === 'tabs'
-              ? html`
-                  <div class="form">
-                    <label>${this._t('tab_mode')}</label>
-                    <select @change=${this._tabModeChanged}>
-                      <option value="per-letter" ?selected=${this._config.tabs.mode === 'per-letter'}>${this._t('per_letter')}</option>
-                      <option value="grouped" ?selected=${this._config.tabs.mode === 'grouped'}>${this._t('grouped')}</option>
-                    </select>
-                  </div>
-                  ${this._config.tabs.mode === 'grouped'
-                    ? html`<div class="form">
-                        <label>${this._t('grouped_breaks')}</label>
-                        <input type="text" .value=${this._config.tabs.grouped_breaks.join(',')} @input=${this._groupedBreaksChanged} />
-                      </div>`
-                    : ''}
-                  <div class="form">
-                    <label><input type="checkbox" .checked=${this._config.tabs.show_all_tab} @change=${this._showAllTabChanged} /> ${this._t('show_all_tab')}</label>
-                  </div>
-                  <div class="form">
-                    <label><input type="checkbox" .checked=${this._config.tabs.show_misc_tab} @change=${this._showMiscTabChanged} /> ${this._t('show_misc_tab')}</label>
-                  </div>
-                `
+      <ha-expansion-panel .header=${this._t('general')}>
+        <div class="form">
+          <label>${this._t('lock_ms')}</label>
+          <input type="number" .value=${this._config.lock_ms} @input=${this._lockChanged} />
+        </div>
+        <div class="form">
+          <label>${this._t('max_width')}</label>
+          <input type="number" .value=${(this._config.max_width ?? '').replace(/px$/, '')} @input=${this._widthChanged} />
+        </div>
+        <div class="form">
+          <label><input type="checkbox" .checked=${this._config.show_remove} @change=${this._removeChanged} /> ${this._t('show_remove_menu')}</label>
+        </div>
+        <div class="form">
+          <label><input type="checkbox" .checked=${this._config.only_self} @change=${this._selfChanged} /> ${this._t('only_self')}</label>
+        </div>
+        <div class="form">
+          <label>${this._t('title')}</label>
+          <input type="text" .value=${this._config.title || ''} @input=${this._titleChanged} />
+        </div>
+        <div class="form">
+          <label>${this._t('currency_override')}</label>
+          <input type="text" .value=${this._config.currency_override || ''} @input=${this._currencyChanged} />
+        </div>
+      </ha-expansion-panel>
+
+      <ha-expansion-panel .header=${this._t('user_selection')}>
+        <div class="form">
+          <label>${this._t('user_selector')}</label>
+          <select @change=${this._userSelectorChanged}>
+            <option value="list" ?selected=${this._config.user_selector === 'list'}>${this._t('user_selector_list')}</option>
+            <option value="tabs" ?selected=${this._config.user_selector === 'tabs'}>${this._t('user_selector_tabs')}</option>
+            <option value="grid" ?selected=${this._config.user_selector === 'grid'}>${this._t('user_selector_grid')}</option>
+          </select>
+        </div>
+      </ha-expansion-panel>
+
+      ${showTabs
+        ? html`<ha-expansion-panel .header=${this._t('tabs_section')}>
+            <div class="form">
+              <label>${this._t('tab_mode')}</label>
+              <select @change=${this._tabModeChanged}>
+                <option value="per-letter" ?selected=${this._config.tabs.mode === 'per-letter'}>${this._t('per_letter')}</option>
+                <option value="grouped" ?selected=${this._config.tabs.mode === 'grouped'}>${this._t('grouped')}</option>
+              </select>
+            </div>
+            ${this._config.tabs.mode === 'grouped'
+              ? html`<div class="form">
+                  <label>${this._t('grouped_breaks')}</label>
+                  <input type="text" .value=${this._config.tabs.grouped_breaks.join(',')} @input=${this._groupedBreaksChanged} />
+                </div>`
               : ''}
+            <div class="form">
+              <label><input type="checkbox" .checked=${this._config.tabs.show_all_tab} @change=${this._showAllTabChanged} /> ${this._t('show_all_tab')}</label>
+            </div>
+            <div class="form">
+              <label><input type="checkbox" .checked=${this._config.tabs.show_misc_tab} @change=${this._showMiscTabChanged} /> ${this._t('show_misc_tab')}</label>
+            </div>
+          </ha-expansion-panel>`
+        : ''}
+
+      ${showGrid
+        ? html`<ha-expansion-panel .header=${this._t('grid_section')}>
             <div class="form">
               <label>${this._t('grid_columns')}</label>
               <input type="text" .value=${this._config.grid.columns} @input=${this._gridColumnsChanged} />
@@ -224,24 +255,33 @@ class TallyListCardEditor extends LitElement {
             <div class="form">
               <label><input type="checkbox" .checked=${this._config.grid.wrap_labels} @change=${this._gridWrapChanged} /> ${this._t('grid_wrap_labels')}</label>
             </div>
-          `
+          </ha-expansion-panel>`
         : ''}
-      <div class="form">
-        <label><input type="checkbox" .checked=${this._config.focus_outline !== false} @change=${this._focusOutlineChanged} /> ${this._t('focus_outline')}</label>
-      </div>
+
+      <ha-expansion-panel .header=${this._t('labels_section')}>
+        <div class="form">
+          <label>${this._t('tab_all_label_label')}</label>
+          <input type="text" .value=${this._config.i18n.tab_all_label} @input=${this._tabAllLabelChanged} />
+        </div>
+        <div class="form">
+          <label>${this._t('tab_misc_label_label')}</label>
+          <input type="text" .value=${this._config.i18n.tab_misc_label} @input=${this._tabMiscLabelChanged} />
+        </div>
+      </ha-expansion-panel>
+
+      <ha-expansion-panel .header=${this._t('accessibility')}>
+        <div class="form">
+          <label><input type="checkbox" .checked=${this._config.focus_outline !== false} @change=${this._focusOutlineChanged} /> ${this._t('focus_outline')}</label>
+        </div>
+      </ha-expansion-panel>
+
       <details class="debug">
         <summary>${this._t('debug')}</summary>
         <div class="form">
-          <label>
-            <input type="checkbox" .checked=${this._config.show_all_users} @change=${this._debugAllChanged} />
-            ${this._t('show_all_users')}
-          </label>
+          <label><input type="checkbox" .checked=${this._config.show_all_users} @change=${this._debugAllChanged} /> ${this._t('show_all_users')}</label>
         </div>
         <div class="form">
-          <label>
-            <input type="checkbox" .checked=${this._config.show_inactive_drinks} @change=${this._debugInactiveChanged} />
-            ${this._t('show_inactive_drinks')}
-          </label>
+          <label><input type="checkbox" .checked=${this._config.show_inactive_drinks} @change=${this._debugInactiveChanged} /> ${this._t('show_inactive_drinks')}</label>
         </div>
         <div class="form">
           <label>${this._t('language')}</label>
@@ -276,6 +316,16 @@ class TallyListCardEditor extends LitElement {
 
   _selfChanged(ev) {
     this._config = { ...this._config, only_self: ev.target.checked };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _titleChanged(ev) {
+    this._config = { ...this._config, title: ev.target.value };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _currencyChanged(ev) {
+    this._config = { ...this._config, currency_override: ev.target.value };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 
@@ -394,6 +444,22 @@ class TallyListCardEditor extends LitElement {
     this._config = {
       ...this._config,
       grid: { ...this._config.grid, wrap_labels: ev.target.checked },
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _tabAllLabelChanged(ev) {
+    this._config = {
+      ...this._config,
+      i18n: { ...this._config.i18n, tab_all_label: ev.target.value },
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _tabMiscLabelChanged(ev) {
+    this._config = {
+      ...this._config,
+      i18n: { ...this._config.i18n, tab_misc_label: ev.target.value },
     };
     fireEvent(this, 'config-changed', { config: this._config });
   }

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,7 @@
 // Tally List Card
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-const CARD_VERSION = 'v06.08.2025';
+const CARD_VERSION = '08.08.2025';
+console.info(`%cTally List Card%c ${CARD_VERSION}`, 'font-weight: bold;', '');
 
 const TL_STRINGS = {
   en: {
@@ -228,6 +229,11 @@ class TallyListCard extends LitElement {
       wrap_labels: false,
       ...(config?.grid || {}),
     };
+    const i18n = {
+      tab_all_label: 'All',
+      tab_misc_label: '#',
+      ...(config?.i18n || {}),
+    };
     this.config = {
       lock_ms: 400,
       max_width: '500px',
@@ -238,10 +244,14 @@ class TallyListCard extends LitElement {
       language: 'auto',
       user_selector: 'list',
       focus_outline: true,
+      title: '',
+      currency_override: '',
       ...config,
     };
     this.config.tabs = tabs;
     this.config.grid = grid;
+    this.config.i18n = i18n;
+    this._currency = this.config.currency_override || this._currency;
     this._disabled = false;
     const width = this._normalizeWidth(this.config.max_width);
     if (width) {
@@ -258,7 +268,7 @@ class TallyListCard extends LitElement {
   }
 
   _t(key) {
-    return t(this.hass, this.config?.language, key);
+    return this.config?.i18n?.[key] || t(this.hass, this.config?.language, key);
   }
 
   _setSelectedUser(name, source) {
@@ -320,19 +330,19 @@ class TallyListCard extends LitElement {
     const min = Number(cfg.min_button_width_px || 88);
     const max = Number(cfg.max_button_width_px || 160);
     const gap = Number(cfg.gap_px || 8);
-    const height = Number(cfg.button_height_px || 56);
     const font = Number(cfg.font_size_rem || 1);
     const wrap = cfg.wrap_labels ? 'normal' : 'nowrap';
     const columnStyle =
       cols && cols !== 'auto'
         ? `grid-template-columns:repeat(${cols},1fr);`
         : `grid-template-columns:repeat(auto-fit,minmax(${min}px,1fr));`;
-    const style = `${columnStyle}gap:${gap}px;--tl-btn-h:${height}px;--tl-btn-font:${font}rem;--tl-btn-min:${min}px;--tl-btn-max:${max}px;--tl-btn-wrap:${wrap};`;
+    const style = `${columnStyle}gap:${gap}px;--tl-btn-font:${font}rem;--tl-btn-min:${min}px;--tl-btn-max:${max}px;--tl-btn-wrap:${wrap};`;
     const pressed = this.selectedUser;
     return html`<div class="user-grid" aria-label="${this._t('name')}" style="${style}">
       ${list.map(u => {
         const name = u.name || u.slug;
-        return html`<button class="user-btn" aria-pressed="${name === pressed}" @click=${() => this._setSelectedUser(name, source)}>${name}</button>`;
+        const isActive = name === pressed;
+        return html`<button class="user-btn${isActive ? ' is-active' : ''}" aria-pressed="${isActive}" @click=${() => this._setSelectedUser(name, source)}>${name}</button>`;
       })}
     </div>`;
   }
@@ -377,7 +387,8 @@ class TallyListCard extends LitElement {
     if (!isAdmin) {
       const own = users.find(u => (u.name || u.slug) === this.selectedUser) || users[0];
       const name = own?.name || own?.slug || '';
-      return html`<div class="controls"><div class="user-label">${name}</div></div>`;
+      this.selectedUser = name;
+      return html`<div class="controls"><button class="user-btn" aria-pressed="true" disabled>${name}</button></div>`;
     }
     const mode = this.config.user_selector || 'list';
     if (mode === 'tabs') return this._renderTabs(users);
@@ -387,6 +398,9 @@ class TallyListCard extends LitElement {
 
   render() {
     if (!this.hass || !this.config) return html``;
+    if (this.config.currency_override) this._currency = this.config.currency_override;
+    const h = this.config?.grid?.button_height_px ?? 56;
+    this.style.setProperty('--tally-action-button-height', `${h}px`);
     let users = this.config.users || this._autoUsers || [];
     if (users.length === 0) {
       return html`<ha-card>${this._t('integration_missing')}</ha-card>`;
@@ -497,7 +511,7 @@ class TallyListCard extends LitElement {
       : `${focusVar}`;
     const selector = this._renderUserSelector(users, isAdmin);
     return html`
-      <ha-card style="${cardStyle}">
+      <ha-card .header=${this.config.title || ''} style="${cardStyle}">
         ${selector}
         <table>
           <thead><tr><th></th><th>${this._t('drink')}</th><th>${this._t('count')}</th><th>${this._t('price')}</th><th>${this._t('sum')}</th></tr></thead>
@@ -817,6 +831,7 @@ class TallyListCard extends LitElement {
   static styles = css`
     :host {
       display: block;
+      --tally-action-button-height: 56px;
     }
     ha-card {
       padding: 16px;
@@ -838,10 +853,6 @@ class TallyListCard extends LitElement {
       justify-content: flex-start;
       align-items: center;
       gap: 8px;
-    }
-    .user-label {
-      font-weight: bold;
-      margin-bottom: 8px;
     }
     .user-tabs {
       display: flex;
@@ -866,14 +877,28 @@ class TallyListCard extends LitElement {
     .user-grid button {
       min-width: var(--tl-btn-min, 88px);
       max-width: var(--tl-btn-max, 160px);
-      height: var(--tl-btn-h, 56px);
       font-size: var(--tl-btn-font, 1rem);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: var(--tl-btn-wrap, nowrap);
     }
-    .user-grid button[aria-pressed='true'] {
-      outline: 2px solid var(--primary-color);
+    .user-btn,
+    .add-button {
+      height: var(--tally-action-button-height);
+      line-height: var(--tally-action-button-height);
+    }
+    .user-btn {
+      border: 1px solid var(--divider-color);
+      background: var(--card-background-color);
+      transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+    }
+    .user-btn[aria-pressed='true'] {
+      border-color: transparent;
+      background: var(--success-color, #2e7d32);
+      color: var(--text-primary-color-on-success, #fff);
+    }
+    .user-btn:active {
+      filter: brightness(0.95);
     }
     .user-tabs button:focus,
     .user-grid button:focus {
@@ -906,8 +931,7 @@ class TallyListCard extends LitElement {
       text-align: left;
     }
     .add-button {
-      height: 32px;
-      width: 32px;
+      width: var(--tally-action-button-height);
       background-color: var(--success-color, #2e7d32);
       color: white;
       border: none;


### PR DESCRIPTION
## Summary
- bump card version to 08.08.2025 and log on load
- reorganize editor options into collapsible sections with new fields
- unify action button heights and always highlight active user in green

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689598890948832e812a5ae2b426ba9e