### PR TITLE
Reduce default button height to 32

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -866,7 +866,7 @@ class TallyListCard extends LitElement {
     .user-grid button {
       min-width: var(--tl-btn-min, 88px);
       max-width: var(--tl-btn-max, 160px);
-      height: var(--tl-btn-h, 56px);
+      height: var(--tl-btn-h, 32px);
       font-size: var(--tl-btn-font, 1rem);
       overflow: hidden;
       text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- lower default button height to 32px

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895a2bc4588832eab3e8ca238a7d1eb