### PR TITLE
Improve tab selector responsiveness

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -338,6 +338,11 @@ class TallyListCard extends LitElement {
     this._uiState = { ...this._uiState, tab: key };
   }
 
+  _onTabPointerDown(e, key) {
+    e.preventDefault();
+    this._changeTab(key);
+  }
+
   _renderTabs(users) {
     const cfg = this.config.tabs || {};
     const data = this._bucketizeUsers(users, cfg);
@@ -361,7 +366,16 @@ class TallyListCard extends LitElement {
     }
     const active = tabs.find(t => t.key === this._uiState.tab) || tabs[0];
     return html`<div class="user-tabs" role="tablist">
-        ${tabs.map(t => html`<button role="tab" aria-selected="${t.key === active.key}" @click=${() => this._changeTab(t.key)}>${t.label}</button>`) }
+        ${tabs.map(
+          t => html`<button
+            role="tab"
+            aria-selected="${t.key === active.key}"
+            @pointerdown=${e => this._onTabPointerDown(e, t.key)}
+            @click=${e => {
+              if (e.detail === 0) this._changeTab(t.key);
+            }}
+          >${t.label}</button>`
+        ) }
       </div>
       ${this._renderUserButtons(active.key === 'all' ? users : active.users, 'tabs')}`;
   }
@@ -850,6 +864,7 @@ class TallyListCard extends LitElement {
       border: none;
       background: var(--secondary-background-color);
       border-radius: 4px;
+      touch-action: manipulation;
     }
     .user-tabs button[aria-selected='true'],
     .user-grid button[aria-pressed='true'] {


### PR DESCRIPTION
## Summary
- React to pointerdown events to switch tabs instantly
- Allow keyboard navigation via click handler
- Add touch-action CSS to remove mobile click delay
- Prevent default pointer behavior for faster tab activation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a9768ce0832e903c35f44d83052e