### PR TITLE
Auto-wrap long tally list button labels

### DIFF
--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -29,9 +29,7 @@ const TL_STRINGS = {
     grid_min_width: 'Min button width (px)',
     grid_max_width: 'Max button width (px)',
     grid_gap: 'Gap (px)',
-    grid_button_height: 'Button height (px)',
     grid_font_size: 'Font size (rem)',
-    grid_wrap_labels: 'Wrap labels',
   },
   de: {
     lock_ms: 'Sperrzeit (ms)',
@@ -60,9 +58,7 @@ const TL_STRINGS = {
     grid_min_width: 'Minimale Buttonbreite (px)',
     grid_max_width: 'Maximale Buttonbreite (px)',
     grid_gap: 'Abstand (px)',
-    grid_button_height: 'Buttonhöhe (px)',
     grid_font_size: 'Schriftgröße (rem)',
-    grid_wrap_labels: 'Text umbrechen',
   },
 };
 
@@ -106,9 +102,7 @@ class TallyListCardEditor extends LitElement {
       min_button_width_px: 88,
       max_button_width_px: 160,
       gap_px: 8,
-      button_height_px: 32,
       font_size_rem: 1.0,
-      wrap_labels: false,
       ...(config?.grid || {}),
     };
     this._config = {
@@ -210,17 +204,10 @@ class TallyListCardEditor extends LitElement {
               <label>${this._t('grid_gap')}</label>
               <input type="number" min="0" .value=${this._config.grid.gap_px} @input=${this._gridGapChanged} />
             </div>
-            <div class="form">
-              <label>${this._t('grid_button_height')}</label>
-              <input type="number" min="1" .value=${this._config.grid.button_height_px} @input=${this._gridButtonHeightChanged} />
-            </div>
-            <div class="form">
-              <label>${this._t('grid_font_size')}</label>
-              <input type="number" step="0.1" min="0.1" .value=${this._config.grid.font_size_rem} @input=${this._gridFontSizeChanged} />
-            </div>
-            <div class="form">
-              <label><input type="checkbox" .checked=${this._config.grid.wrap_labels} @change=${this._gridWrapChanged} /> ${this._t('grid_wrap_labels')}</label>
-            </div>
+              <div class="form">
+                <label>${this._t('grid_font_size')}</label>
+                <input type="number" step="0.1" min="0.1" .value=${this._config.grid.font_size_rem} @input=${this._gridFontSizeChanged} />
+              </div>
           `
         : ''}
       <details class="debug">
@@ -366,28 +353,11 @@ class TallyListCardEditor extends LitElement {
     fireEvent(this, 'config-changed', { config: this._config });
   }
 
-  _gridButtonHeightChanged(ev) {
-    const v = Math.max(1, Number(ev.target.value));
-    this._config = {
-      ...this._config,
-      grid: { ...this._config.grid, button_height_px: v },
-    };
-    fireEvent(this, 'config-changed', { config: this._config });
-  }
-
   _gridFontSizeChanged(ev) {
     const v = Math.max(0.1, Number(ev.target.value));
     this._config = {
       ...this._config,
       grid: { ...this._config.grid, font_size_rem: v },
-    };
-    fireEvent(this, 'config-changed', { config: this._config });
-  }
-
-  _gridWrapChanged(ev) {
-    this._config = {
-      ...this._config,
-      grid: { ...this._config.grid, wrap_labels: ev.target.checked },
     };
     fireEvent(this, 'config-changed', { config: this._config });
   }


### PR DESCRIPTION
## Summary
- Automatically wrap long user names and equalize button height
- Remove configurable button height and label wrap options
- Correct grid height calculation so multi-line names fit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68961f220848832e8a159e16169e6bcf