### PR TITLE
Always show misc tab for unassigned users

### DIFF
--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -24,7 +24,6 @@ const TL_STRINGS = {
     grouped: 'Grouped',
     grouped_breaks: 'Grouped breaks',
     show_all_tab: 'Show "All" tab',
-    show_misc_tab: 'Show "#" tab',
     grid_columns: 'Grid columns',
     grid_min_width: 'Min button width (px)',
     grid_max_width: 'Max button width (px)',
@@ -53,7 +52,6 @@ const TL_STRINGS = {
     grouped: 'Gruppiert',
     grouped_breaks: 'Gruppierte Bereiche',
     show_all_tab: 'Tab "Alle" anzeigen',
-    show_misc_tab: 'Tab "#" anzeigen',
     grid_columns: 'Spalten',
     grid_min_width: 'Minimale Buttonbreite (px)',
     grid_max_width: 'Maximale Buttonbreite (px)',
@@ -94,7 +92,6 @@ class TallyListCardEditor extends LitElement {
       mode: 'per-letter',
       grouped_breaks: ['A–E', 'F–J', 'K–O', 'P–T', 'U–Z'],
       show_all_tab: true,
-      show_misc_tab: true,
       ...(config?.tabs || {}),
     };
     const grid = {
@@ -182,9 +179,6 @@ class TallyListCardEditor extends LitElement {
                     : ''}
                   <div class="form">
                     <label><input type="checkbox" .checked=${this._config.tabs.show_all_tab} @change=${this._showAllTabChanged} /> ${this._t('show_all_tab')}</label>
-                  </div>
-                  <div class="form">
-                    <label><input type="checkbox" .checked=${this._config.tabs.show_misc_tab} @change=${this._showMiscTabChanged} /> ${this._t('show_misc_tab')}</label>
                   </div>
                 `
               : ''}
@@ -304,14 +298,6 @@ class TallyListCardEditor extends LitElement {
     this._config = {
       ...this._config,
       tabs: { ...this._config.tabs, show_all_tab: ev.target.checked },
-    };
-    fireEvent(this, 'config-changed', { config: this._config });
-  }
-
-  _showMiscTabChanged(ev) {
-    this._config = {
-      ...this._config,
-      tabs: { ...this._config.tabs, show_misc_tab: ev.target.checked },
     };
     fireEvent(this, 'config-changed', { config: this._config });
   }

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -61,7 +61,6 @@ const TL_STRINGS = {
     grouped: 'Grouped',
     grouped_breaks: 'Grouped breaks',
     show_all_tab: 'Show "All" tab',
-    show_misc_tab: 'Show "#" tab',
     grid_columns: 'Grid columns',
     grid_min_width: 'Min button width (px)',
     grid_max_width: 'Max button width (px)',
@@ -126,7 +125,6 @@ const TL_STRINGS = {
     grouped: 'Gruppiert',
     grouped_breaks: 'Gruppierte Bereiche',
     show_all_tab: 'Tab "Alle" anzeigen',
-    show_misc_tab: 'Tab "#" anzeigen',
     grid_columns: 'Spalten',
     grid_min_width: 'Minimale Buttonbreite (px)',
     grid_max_width: 'Maximale Buttonbreite (px)',
@@ -229,7 +227,6 @@ class TallyListCard extends LitElement {
       mode: 'per-letter',
       grouped_breaks: ['A–E', 'F–J', 'K–O', 'P–T', 'U–Z'],
       show_all_tab: true,
-      show_misc_tab: true,
       ...(config?.tabs || {}),
     };
     const grid = {
@@ -401,7 +398,7 @@ class TallyListCard extends LitElement {
       const letters = Array.from(data.letters.keys()).sort((a, b) => a.localeCompare(b, locale));
       tabs = letters.map(l => ({ key: l, label: l, users: data.letters.get(l) }));
     }
-    if (cfg.show_misc_tab !== false && data.misc.length > 0) {
+    if (data.misc.length > 0) {
       tabs.push({ key: '#', label: this._t('tab_misc_label'), users: data.misc });
     }
     if (cfg.show_all_tab !== false) {
@@ -1036,7 +1033,6 @@ class TallyListCardEditor extends LitElement {
       mode: 'per-letter',
       grouped_breaks: ['A–E', 'F–J', 'K–O', 'P–T', 'U–Z'],
       show_all_tab: true,
-      show_misc_tab: true,
       ...(config?.tabs || {}),
     };
     const grid = {
@@ -1124,9 +1120,6 @@ class TallyListCardEditor extends LitElement {
                     : ''}
                   <div class="form">
                     <label><input type="checkbox" .checked=${this._config.tabs.show_all_tab} @change=${this._showAllTabChanged} /> ${this._t('show_all_tab')}</label>
-                  </div>
-                  <div class="form">
-                    <label><input type="checkbox" .checked=${this._config.tabs.show_misc_tab} @change=${this._showMiscTabChanged} /> ${this._t('show_misc_tab')}</label>
                   </div>
                 `
               : ''}
@@ -1288,14 +1281,6 @@ class TallyListCardEditor extends LitElement {
     this._config = {
       ...this._config,
       tabs: { ...this._config.tabs, show_all_tab: ev.target.checked },
-    };
-    this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: this._config }, bubbles: true, composed: true }));
-  }
-
-  _showMiscTabChanged(ev) {
-    this._config = {
-      ...this._config,
-      tabs: { ...this._config.tabs, show_misc_tab: ev.target.checked },
     };
     this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: this._config }, bubbles: true, composed: true }));
   }


### PR DESCRIPTION
## Summary
- drop configuration for showing the `#` tab
- automatically display unassigned users in the `#` tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68962493569c832ea5c56c63051b496d