### PR TITLE
Use zero to represent automatic grid columns

### DIFF
--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -24,7 +24,7 @@ const TL_STRINGS = {
     grouped: 'Grouped',
     grouped_breaks: 'Grouped breaks',
     show_all_tab: 'Show "All" tab',
-    grid_columns: 'Grid columns',
+    grid_columns: 'Grid columns (0 = auto)',
   },
   de: {
     lock_ms: 'Sperrzeit (ms)',
@@ -48,7 +48,7 @@ const TL_STRINGS = {
     grouped: 'Gruppiert',
     grouped_breaks: 'Gruppierte Bereiche',
     show_all_tab: 'Tab "Alle" anzeigen',
-    grid_columns: 'Spalten',
+    grid_columns: 'Spalten (0 = automatisch)',
   },
 };
 
@@ -87,7 +87,7 @@ class TallyListCardEditor extends LitElement {
       ...(config?.tabs || {}),
     };
     const grid = {
-      columns: 'auto',
+      columns: 0,
       ...(config?.grid || {}),
     };
     this._config = {
@@ -276,7 +276,8 @@ class TallyListCardEditor extends LitElement {
 
   _gridColumnsChanged(ev) {
     const val = ev.target.value.trim();
-    const columns = val === '' || val === 'auto' ? 'auto' : Math.max(1, Number(val));
+    const num = Number(val);
+    const columns = val === '' || num === 0 ? 0 : Math.max(1, num);
     this._config = {
       ...this._config,
       grid: { ...this._config.grid, columns },

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -61,7 +61,7 @@ const TL_STRINGS = {
     grouped: 'Grouped',
     grouped_breaks: 'Grouped breaks',
     show_all_tab: 'Show "All" tab',
-    grid_columns: 'Grid columns',
+    grid_columns: 'Grid columns (0 = auto)',
   },
   de: {
     card_name: 'Strichliste Karte',
@@ -121,7 +121,7 @@ const TL_STRINGS = {
     grouped: 'Gruppiert',
     grouped_breaks: 'Gruppierte Bereiche',
     show_all_tab: 'Tab "Alle" anzeigen',
-    grid_columns: 'Spalten',
+    grid_columns: 'Spalten (0 = automatisch)',
   },
 };
 
@@ -222,7 +222,7 @@ class TallyListCard extends LitElement {
       ...(config?.tabs || {}),
     };
     const grid = {
-      columns: 'auto',
+      columns: 0,
       ...(config?.grid || {}),
     };
     this.config = {
@@ -312,9 +312,9 @@ class TallyListCard extends LitElement {
 
   _renderUserButtons(list, source) {
     const cfg = this.config.grid || {};
-    const cols = cfg.columns;
+    const cols = Number(cfg.columns);
     const columnStyle =
-      cols && cols !== 'auto'
+      cols > 0
         ? `grid-template-columns:repeat(${cols},1fr);`
         : `grid-template-columns:repeat(auto-fit,minmax(0,1fr));`;
     const style = `${columnStyle}--tl-btn-h:32px;`;
@@ -1024,7 +1024,7 @@ class TallyListCardEditor extends LitElement {
       ...(config?.tabs || {}),
     };
     const grid = {
-      columns: 'auto',
+      columns: 0,
       ...(config?.grid || {}),
     };
     this._config = {
@@ -1255,7 +1255,8 @@ class TallyListCardEditor extends LitElement {
 
   _gridColumnsChanged(ev) {
     const val = ev.target.value.trim();
-    const columns = val === '' || val === 'auto' ? 'auto' : Math.max(1, Number(val));
+    const num = Number(val);
+    const columns = val === '' || num === 0 ? 0 : Math.max(1, num);
     this._config = {
       ...this._config,
       grid: { ...this._config.grid, columns },


### PR DESCRIPTION
## Summary
- clarify that 0 selects automatic grid columns in card and editor labels
- interpret 0 as automatic column count throughout configuration and rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68962f583a28832eaee15ed327e66fec