### PR TITLE
Add count selection to tally list card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -34,16 +34,19 @@ type: custom:tally-list-card
 ```
 Alle von der Integration erkannten Nutzer erscheinen in der Auswahlliste. Administratoren (laut Tally‑List‑Integration) können jeden Nutzer wählen, normale Nutzer nur sich selbst. Getränkepreise stammen aus Sensoren `sensor.price_list_<getränk>_price`. Falls `sensor.price_list_free_amount` existiert, wird dieser Betrag jedem Nutzer gutgeschrieben. Sensoren `sensor.<name>_amount_due` überschreiben den berechneten Betrag.
 
-Ein Klick auf **+1** fügt ein Getränk hinzu:
+Unter der Nutzerauswahl ermöglicht eine neue Buttonreihe, wie viele Getränke auf einmal hinzugefügt oder entfernt werden (1, 3, 5 oder 10). Die gewählte Anzahl wird hervorgehoben und für alle folgenden Aktionen verwendet.
+
+Ein Klick auf **+X** fügt die ausgewählte Anzahl an Getränken hinzu:
 
 ```yaml
 action: tally_list.add_drink
 data:
   user: Robin
   drink: Wasser
+  count: 3
 ```
 
-Über den Button **Getränk entfernen** wird ein Getränk mit `tally_list.remove_drink` abgezogen.
+Über den Button **Getränk entfernen** werden Getränke mit `tally_list.remove_drink` abgezogen. Wird `count` weggelassen, beträgt der Standardwert `1`.
 
 ## Konfigurationsoptionen
 

--- a/README.md
+++ b/README.md
@@ -34,16 +34,19 @@ type: custom:tally-list-card
 ```
 All users detected by the integration appear in the selector. By default this is a dropdown list, but admins (as defined in the Tally List integration) may switch to tabs or a button grid via the `user_selector` option. Regular users only see their own name and cannot change it. Drink prices are taken from sensors named `sensor.price_list_<drink>_price`. If `sensor.price_list_free_amount` exists, its value is deducted from each user's total. Sensors named `sensor.<name>_amount_due` override the calculated amount due.
 
-Pressing **+1** adds a drink:
+Below the user selection a row of buttons lets you choose how many drinks to add or remove at once (1, 3, 5, or 10). The highlighted value is used for all subsequent actions.
+
+Pressing **+X** adds the selected number of drinks:
 
 ```yaml
 action: tally_list.add_drink
 data:
   user: Robin
   drink: Wasser
+  count: 3
 ```
 
-The **Remove drink** button subtracts a drink with a `tally_list.remove_drink` call.
+The **Remove drink** button subtracts drinks with a `tally_list.remove_drink` call. If `count` is omitted, both services default to `1`.
 
 ## Configuration options
 


### PR DESCRIPTION
## Summary
- Add configurable count selection buttons (1/3/5/10) below user picker
- Pass selected `count` to `tally_list.add_drink` and `tally_list.remove_drink`
- Document new count feature in English and German READMEs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896332da6a4832e9b925848b92836ce