### PR TITLE
Implement step size segmented control and user tab styling

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -77,4 +77,5 @@ Optionen:
 * **max_entries** – Anzahl angezeigter Nutzer begrenzen (`0` = unbegrenzt).
 * **hide_free** – Nutzer ohne offenen Betrag ausblenden.
 * **show_copy** – Schaltfläche **Tabelle kopieren** anzeigen.
+* **show_step_select** – Auswahl der Schrittweiten anzeigen.
 

--- a/README.md
+++ b/README.md
@@ -78,4 +78,5 @@ Options:
 * **max_entries** – Limit how many users are shown (`0` = no limit).
 * **hide_free** – Hide users who owe nothing.
 * **show_copy** – Show the "Tabelle kopieren" button.
+* **show_step_select** – Show buttons to select the step size.
 


### PR DESCRIPTION
## Summary
- Add segmented control for selecting drink step size with label and configurable visibility
- Reset step size on user change and update +/− buttons instantly
- Style user tabs with red/green backgrounds and document new option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896395d3b20832ea522c1c745373e46