### PR TITLE
style: align ranking card with main card

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1572,42 +1572,28 @@ class TallyDueRankingCard extends LitElement {
     css`
       .controls {
         display: flex;
-        justify-content: flex-start;
+        justify-content: space-between;
         align-items: center;
+        flex-wrap: wrap;
         gap: 8px;
         margin-bottom: 8px;
-        flex-wrap: wrap;
       }
       .controls select {
         padding: 4px 8px;
-        min-width: 160px;
-        font-size: 1rem;
-        height: 32px;
+        min-width: 120px;
+        font-size: 14px;
+        height: 44px;
         box-sizing: border-box;
+        border: 1px solid var(--ha-card-border-color, var(--divider-color));
+        border-radius: 12px;
+        background: #2b2b2b;
+        color: #ddd;
       }
-      .reset-container {
-        text-align: right;
-        margin-top: 8px;
+      table thead tr {
+        background: var(--ha-card-background, #1e1e1e);
       }
-      .reset-container button {
-        padding: 4px 8px;
-        height: 32px;
-        box-sizing: border-box;
-        background-color: var(--error-color, #c62828);
-        color: white;
-        border: none;
-        border-radius: 4px;
-      }
-      .copy-container {
-        text-align: right;
-        margin-top: 8px;
-      }
-      .copy-container button {
-        padding: 4px 8px;
-        height: 32px;
-        box-sizing: border-box;
-        border: none;
-        border-radius: 4px;
+      table th {
+        font-weight: 600;
       }
     `,
   ];


### PR DESCRIPTION
## Summary
- unify ranking card UI with main card
- style sort dropdown to match main card selects
- match table header styling to main card tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689653a28724832e92898fb245664d31