### PR TITLE
Remove status indicator from user chips

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1083,15 +1083,7 @@ class TallyListCard extends LitElement {
       color: #ddd;
     }
     .user-chip::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      border-radius: inherit;
-      box-shadow: inset 4px 0 0 0 var(--chip-indicator, #E74C3C);
-      pointer-events: none;
-    }
-    .user-chip.active::before {
-      --chip-indicator: var(--success-color, #2e7d32);
+      display: none;
     }
     .user-grid {
       display: grid;
@@ -1117,19 +1109,11 @@ class TallyListCard extends LitElement {
       transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
     }
     .user-grid button::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      border-radius: inherit;
-      box-shadow: inset 4px 0 0 0 var(--chip-indicator, var(--error-color, #c62828));
-      pointer-events: none;
+      display: none;
     }
     .user-grid button[aria-pressed='true'] {
       background: var(--success-color, #2e7d32);
       color: #fff;
-    }
-    .user-grid button[aria-pressed='true']::before {
-      --chip-indicator: var(--success-color, #2e7d32);
     }
     .tab:focus,
     .segment:focus,


### PR DESCRIPTION
## Summary
- drop pseudo-element indicator from user chips and grid buttons
- keep green background for active users and dark neutral for inactive chips

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896fbed875c832eb3e5c4815336c5c5