### PR TITLE
style: align ranking card with main card

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -960,11 +960,34 @@ class TallyListCard extends LitElement {
     :host {
       display: block;
     }
+    :root,
+    .tally-theme {
+      --card-bg: var(--ha-card-background, #151515);
+      --card-border: var(--ha-card-border-color, #2a2a2a);
+      --radius: 12px;
+      --row-h: 44px;
+      --text: #fff;
+      --muted: #cfcfcf;
+      --header-bg: #222;
+      --btn-neutral: #3b3b3b;
+      --btn-danger: #d9534f;
+    }
     ha-card {
       padding: 16px;
       text-align: center;
       margin: 0 auto;
       max-width: var(--dcc-max-width, none);
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: var(--radius);
+      color: var(--text);
+    }
+    .ranking-card {
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: var(--radius);
+      padding: 16px;
+      color: var(--text);
     }
     .controls {
       display: flex;
@@ -1236,6 +1259,57 @@ class TallyListCard extends LitElement {
     .reset-container button {
       background-color: var(--error-color, #c62828);
       color: white;
+    }
+    .table--head,
+    .ranking-table thead tr {
+      background: var(--header-bg);
+      color: var(--text);
+      height: var(--row-h);
+    }
+    .ranking-table thead th {
+      padding: 0 12px;
+      font-weight: 700;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+    .ranking-table tbody td {
+      padding: 10px 12px;
+    }
+    .sort-select {
+      height: var(--row-h);
+      border-radius: var(--radius);
+      background: var(--btn-neutral);
+      color: var(--text);
+      padding: 0 12px;
+      border: none;
+    }
+    .btn {
+      height: var(--row-h);
+      border-radius: var(--radius);
+      padding: 0 16px;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: none;
+    }
+    .btn--neutral {
+      background: var(--btn-neutral);
+      color: var(--text);
+    }
+    .btn--danger {
+      background: var(--btn-danger);
+      color: #fff;
+    }
+    .button-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 8px;
+    }
+    .button-row .btn {
+      flex: 1 1 auto;
+      min-width: 160px;
     }
     table {
       width: 100%;
@@ -1570,44 +1644,9 @@ class TallyDueRankingCard extends LitElement {
   static styles = [
     TallyListCard.styles,
     css`
-      .controls {
-        display: flex;
-        justify-content: flex-start;
-        align-items: center;
-        gap: 8px;
-        margin-bottom: 8px;
-        flex-wrap: wrap;
-      }
-      .controls select {
-        padding: 4px 8px;
-        min-width: 160px;
-        font-size: 1rem;
-        height: 32px;
-        box-sizing: border-box;
-      }
-      .reset-container {
-        text-align: right;
-        margin-top: 8px;
-      }
-      .reset-container button {
-        padding: 4px 8px;
-        height: 32px;
-        box-sizing: border-box;
-        background-color: var(--error-color, #c62828);
-        color: white;
-        border: none;
-        border-radius: 4px;
-      }
-      .copy-container {
-        text-align: right;
-        margin-top: 8px;
-      }
-      .copy-container button {
-        padding: 4px 8px;
-        height: 32px;
-        box-sizing: border-box;
-        border: none;
-        border-radius: 4px;
+      .ranking-table {
+        width: 100%;
+        border-collapse: collapse;
       }
     `,
   ];
@@ -1704,32 +1743,32 @@ class TallyDueRankingCard extends LitElement {
     const sortMenu = this.config.sort_menu
       ? html`<div class="controls">
           <label>${this._t('sort_label')}</label>
-          <select @change=${this._sortMenuChanged}>
+          <select class="sort-select" @change=${this._sortMenuChanged}>
             <option value="due_desc" ?selected=${sortBy === 'due_desc'}>${this._t('sort_due_desc')}</option>
             <option value="due_asc" ?selected=${sortBy === 'due_asc'}>${this._t('sort_due_asc')}</option>
             <option value="name" ?selected=${sortBy === 'name'}>${this._t('sort_name')}</option>
           </select>
         </div>`
       : '';
-    const copyButton = this.config.show_copy !== false
-      ? html`<div class="copy-container"><button @click=${this._copyRanking}>${this._t('copy_table')}</button></div>`
+    const copyBtn = this.config.show_copy !== false
+      ? html`<button class="btn btn--neutral" @click=${this._copyRanking}>${this._t('copy_table')}</button>`
       : '';
-    const resetButton = (isAdmin || this.config.show_reset_everyone) &&
+    const resetBtn = (isAdmin || this.config.show_reset_everyone) &&
       this.config.show_reset !== false
-      ? html`<div class="reset-container">
-          <button @click=${this._resetAllTallies}>${this._t('reset_all')}</button>
-        </div>`
+      ? html`<button class="btn btn--danger" @click=${this._resetAllTallies}>${this._t('reset_all')}</button>`
+      : '';
+    const buttonRow = copyBtn || resetBtn
+      ? html`<div class="button-row">${copyBtn}${resetBtn}</div>`
       : '';
     return html`
-      <ha-card style="${cardStyle}">
+      <ha-card class="ranking-card" style="${cardStyle}">
         ${sortMenu}
-        <table>
-          <thead><tr><th>#</th><th>${this._t('name')}</th><th>${this._t('amount_due')}</th></tr></thead>
+        <table class="ranking-table">
+          <thead class="table--head"><tr><th>#</th><th>${this._t('name')}</th><th>${this._t('amount_due')}</th></tr></thead>
           <tbody>${rows}</tbody>
           ${totalRow}
         </table>
-        ${copyButton}
-        ${resetButton}
+        ${buttonRow}
       </ha-card>
     `;
   }


### PR DESCRIPTION
## Summary
- centralize card theme variables and container styles for consistent look
- style ranking card dropdown, table header, and buttons using shared classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689653a28724832e92898fb245664d31