### PR TITLE
Use local lit modules for faster card loading

### DIFF
--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'https://unpkg.com/lit?module';
+import { LitElement, html, css } from 'lit';
 const CARD_VERSION = '09.08.2025';
 
 const TL_STRINGS = {

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,6 @@
 // Tally List Card
-import { LitElement, html, css } from 'https://unpkg.com/lit?module';
-import { repeat } from 'https://unpkg.com/lit/directives/repeat.js?module';
+import { LitElement, html, css } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
 const CARD_VERSION = '09.08.2025';
 
 const TL_STRINGS = {


### PR DESCRIPTION
## Summary
- load lit from Home Assistant instead of remote CDN for the tally list card and editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897192103c0832e96c9d467517555a2