### PR TITLE
Improve ranking button feedback

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -50,7 +50,8 @@ const TL_STRINGS = {
     max_entries: 'Maximum entries (0 = all)',
     sort_label: 'Sort:',
     version: 'Version',
-    copy_success: 'Text copied to clipboard!',
+    copy_done: 'Copied!',
+    reset_done: 'Reset!',
     reset_confirm_prompt: 'Type "YES I WANT TO" to reset all tallies:',
     tab_all_label: 'All',
     tab_misc_label: '#',
@@ -112,7 +113,8 @@ const TL_STRINGS = {
     max_entries: 'Maximale Einträge (0 = alle)',
     sort_label: 'Sortierung:',
     version: 'Version',
-    copy_success: 'Text in die Zwischenablage kopiert!',
+    copy_done: 'Kopiert!',
+    reset_done: 'Zurückgesetzt!',
     reset_confirm_prompt: 'Zum Zurücksetzen aller Striche "JA ICH WILL" eingeben:',
     tab_all_label: 'Alle',
     tab_misc_label: '#',
@@ -1682,7 +1684,7 @@ class TallyDueRankingCard extends LitElement {
       display: block;
     }
     .ranking-card {
-      --radius: var(--ha-card-border-radius, 12px);
+      --radius: var(--ha-button-border-radius, 4px);
       --row-h: 44px;
       --btn-neutral: var(--secondary-background-color, #3b3b3b);
       --btn-danger: var(--error-color, #d9534f);
@@ -1739,6 +1741,13 @@ class TallyDueRankingCard extends LitElement {
       align-items: center;
       justify-content: center;
       border: none;
+      cursor: pointer;
+      overflow: hidden;
+      transition: background 0.2s, filter 0.2s, transform 0.05s;
+    }
+    .ranking-card .btn:active {
+      filter: brightness(1.2);
+      transform: scale(0.96);
     }
     .ranking-card .btn--neutral {
       background: var(--btn-neutral);
@@ -2105,7 +2114,7 @@ class TallyDueRankingCard extends LitElement {
     this._sortBy = ev.target.value;
   }
 
-  _copyRanking() {
+  _copyRanking(ev) {
     let users = this.config.users || this._autoUsers || [];
     const userNames = [this.hass.user?.name, ...this._currentPersonNames()];
     const isAdmin = userNames.some(n => (this._tallyAdmins || []).includes(n));
@@ -2158,22 +2167,30 @@ class TallyDueRankingCard extends LitElement {
       lines.push(`${this._t('total')}: ${this._formatPrice(total)} ${this._currency}`);
     }
     navigator.clipboard.writeText(lines.join('\n')).then(() => {
-      this.dispatchEvent(
-        new CustomEvent('hass-notification', {
-          detail: { message: this._t('copy_success') },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      const btn = ev?.currentTarget;
+      if (btn) {
+        const orig = btn.textContent;
+        const width = btn.offsetWidth;
+        btn.style.width = width + 'px';
+        btn.textContent = this._t('copy_done');
+        setTimeout(() => {
+          btn.textContent = orig;
+          btn.style.width = '';
+        }, 2000);
+      }
     });
   }
 
-  _resetAllTallies() {
+  _resetAllTallies(ev) {
     const input = prompt(this._t('reset_confirm_prompt'));
     const normalized = (input || '').trim().toUpperCase();
     if (normalized !== 'JA ICH WILL' && normalized !== 'YES I WANT TO') {
       return;
     }
+    const btn = ev?.currentTarget;
+    const orig = btn?.textContent;
+    const width = btn?.offsetWidth;
+    if (btn) btn.style.width = width + 'px';
     const users = this.config.users || this._autoUsers || [];
     for (const u of users) {
       const buttonId = `button.${u.slug}_reset_tally`;
@@ -2184,6 +2201,13 @@ class TallyDueRankingCard extends LitElement {
       if (u.amount_due_entity) {
         this.hass.callService('homeassistant', 'update_entity', { entity_id: u.amount_due_entity });
       }
+    }
+    if (btn) {
+      btn.textContent = this._t('reset_done');
+      setTimeout(() => {
+        btn.textContent = orig;
+        btn.style.width = '';
+      }, 2000);
     }
   }
 }


### PR DESCRIPTION
## Summary
- align ranking card buttons with standard Home Assistant border radius and add press feedback
- show temporary confirmation text on copy/reset actions without changing button size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689771eb9354832e9404bb9dce13db1f