### PR TITLE
style: match copy button color to remove menu

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1741,8 +1741,9 @@ class TallyDueRankingCard extends LitElement {
       border: none;
     }
     .ranking-card .btn--neutral {
-      background: var(--btn-neutral);
-      color: var(--primary-text-color, #fff);
+      background: #2b2b2b;
+      color: #fff;
+      border: 1px solid var(--ha-card-border-color);
     }
     .ranking-card .btn--danger {
       background: var(--btn-danger);


### PR DESCRIPTION
## Summary
- match copy table button color to the drink selection menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977b18fc28832e971bba3b0a98846c