### PR TITLE
style: match copy button color to remove menu

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1684,7 +1684,7 @@ class TallyDueRankingCard extends LitElement {
     .ranking-card {
       --radius: var(--ha-card-border-radius, 12px);
       --row-h: 44px;
-      --btn-neutral: var(--secondary-background-color, #3b3b3b);
+      --btn-neutral: #2b2b2b;
       --btn-danger: var(--error-color, #d9534f);
       padding: 16px;
     }
@@ -1743,6 +1743,7 @@ class TallyDueRankingCard extends LitElement {
     .ranking-card .btn--neutral {
       background: var(--btn-neutral);
       color: var(--primary-text-color, #fff);
+      border: 1px solid var(--ha-card-border-color);
     }
     .ranking-card .btn--danger {
       background: var(--btn-danger);


### PR DESCRIPTION
## Summary
- use a dark neutral palette on ranking card buttons to match the remove menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977b18fc28832e971bba3b0a98846c