### PR TITLE
style: align dropdown colors

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1235,12 +1235,17 @@ class TallyListCard extends LitElement {
       filter: brightness(1.1);
     }
     .user-select select {
-      padding: 4px 8px;
+      padding: 0 12px;
       min-width: 120px;
       font-size: 14px;
       height: 44px;
+      line-height: 44px;
       box-sizing: border-box;
       border-radius: 12px;
+      border: 1px solid var(--ha-card-border-color);
+      background: var(--btn-neutral, #2b2b2b);
+      color: var(--primary-text-color, #fff);
+      appearance: none;
     }
     .action-btn {
       display: inline-flex;
@@ -1721,10 +1726,14 @@ class TallyDueRankingCard extends LitElement {
     }
     .ranking-card .sort-select {
       height: var(--row-h);
+      line-height: var(--row-h);
       border-radius: var(--radius);
       background: var(--btn-neutral);
       color: var(--primary-text-color, #fff);
       padding: 0 12px;
+      border: 1px solid var(--ha-card-border-color);
+      appearance: none;
+      box-sizing: border-box;
     }
     .ranking-card .button-row {
       display: flex;


### PR DESCRIPTION
## Summary
- Ensure user selection dropdown matches drink removal menu styling
- Align ranking card sort dropdown with same neutral menu colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689782998d2c832e8ce5db287198b718