### PR TITLE
Align ranking sort menu rounding with name selector

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1727,7 +1727,7 @@ class TallyDueRankingCard extends LitElement {
     .ranking-card .sort-select {
       height: var(--row-h);
       line-height: var(--row-h);
-      border-radius: var(--radius);
+      border-radius: 12px;
       background: var(--btn-neutral);
       color: var(--primary-text-color, #fff);
       padding: 0 12px;


### PR DESCRIPTION
## Summary
- Match ranking card sort menu border radius to the tally list name selector for consistent appearance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897850cd558832eb5fe147de0192f93