### PR TITLE
Remove content padding from tally list card

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1142,9 +1142,6 @@ class TallyListCard extends LitElement {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
     }
-    .content {
-      padding: 12px 16px;
-    }
     .spacer {
       height: 12px;
     }


### PR DESCRIPTION
## Summary
- remove obsolete `.content` padding from tally list card styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689787b3fb24832e98d3aeb16b4ea992