### PR TITLE
Add spacing above tally list table

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1326,6 +1326,7 @@ class TallyListCard extends LitElement {
     }
     .obere-zeile {
       grid-column: 1 / -1;
+      margin-top: 8px;
     }
     .plus-btn {
       grid-column: 1;


### PR DESCRIPTION
## Summary
- add 8px top margin for tally list table in card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689791652360832eb3798a17d9a87821