### PR TITLE
Add option to hide step selection buttons

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -55,6 +55,7 @@ Folgende Optionen stehen im UI zur Verfügung:
 * **Sperrzeit (ms)** – Wie lange die Buttons nach dem Drücken deaktiviert bleiben. Standard `400`.
 * **Maximale Breite (px)** – Begrenzung der Kartenbreite. Standard `500`.
 * **Entfernen-Menü anzeigen** – Ein-/Ausblenden des Menüs zum Entfernen.
+* **Schrittweiten-Auswahl anzeigen** – Schaltflächen zur Auswahl der Schrittweite (1, 3, 5, 10) anzeigen.
 * **Nur sich selbst zeigen** – Auswahl auch für Admins auf den eingeloggten Nutzer beschränken.
 * **Sprache** – **Auto**, **Deutsch** oder **English** erzwingen.
 * **Version** – Zeigt die installierte Version an.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The card offers the following options in the UI:
 * **Lock time (ms)** – Duration the buttons stay disabled after pressing them. Default `400`.
 * **Maximum width (px)** – Limit card width. Default `500`.
 * **Show remove menu** – Enable/disable the remove-drink dropdown.
+* **Show step selection** – Show buttons to select the step size (1, 3, 5, 10).
 * **Only show self** – Limit selection to the logged‑in user even for admins.
 * **User selector** – Choose between **list**, **tabs**, or **grid** for selecting users.
 * **Language** – Force **Auto**, **Deutsch**, or **English**.

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -7,6 +7,7 @@ const TL_STRINGS = {
     max_width: 'Maximum width (px)',
     show_remove_menu: 'Show remove menu',
     only_self: 'Only show own user even for admins',
+    show_step_select: 'Show step selection',
     show_all_users: 'Show all users',
     show_inactive_drinks: 'Show inactive drinks',
     debug: 'Debug',
@@ -31,6 +32,7 @@ const TL_STRINGS = {
     max_width: 'Maximale Breite (px)',
     show_remove_menu: 'Entfernen-Menü anzeigen',
     only_self: 'Trotz Admin nur eigenen Nutzer anzeigen',
+    show_step_select: 'Schrittweiten-Auswahl anzeigen',
     show_all_users: 'Alle Nutzer anzeigen',
     show_inactive_drinks: 'Inaktive Getränke anzeigen',
     debug: 'Debug',
@@ -95,6 +97,7 @@ class TallyListCardEditor extends LitElement {
       max_width: '500px',
       show_remove: true,
       only_self: false,
+      show_step_select: true,
       show_all_users: false,
       show_inactive_drinks: false,
       language: 'auto',
@@ -132,6 +135,12 @@ class TallyListCardEditor extends LitElement {
         <label>
           <input type="checkbox" .checked=${this._config.show_remove} @change=${this._removeChanged} />
           ${this._t('show_remove_menu')}
+        </label>
+      </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.show_step_select !== false} @change=${this._stepSelectChanged} />
+          ${this._t('show_step_select')}
         </label>
       </div>
       <div class="form">
@@ -218,6 +227,11 @@ class TallyListCardEditor extends LitElement {
 
   _removeChanged(ev) {
     this._config = { ...this._config, show_remove: ev.target.checked };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _stepSelectChanged(ev) {
+    this._config = { ...this._config, show_step_select: ev.target.checked };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1431,6 +1431,7 @@ class TallyListCardEditor extends LitElement {
     const idLock = this._fid('lock-ms');
     const idWidth = this._fid('max-width');
     const idShowRemove = this._fid('show-remove');
+    const idShowStepSelect = this._fid('show-step-select');
     const idOnlySelf = this._fid('only-self');
     const idUserSelector = this._fid('user-selector');
     const idTabMode = this._fid('tab-mode');
@@ -1452,6 +1453,10 @@ class TallyListCardEditor extends LitElement {
       <div class="form">
         <input id="${idShowRemove}" name="show_remove" type="checkbox" .checked=${this._config.show_remove} @change=${this._removeChanged} />
         <label for="${idShowRemove}">${this._t('show_remove_menu')}</label>
+      </div>
+      <div class="form">
+        <input id="${idShowStepSelect}" name="show_step_select" type="checkbox" .checked=${this._config.show_step_select !== false} @change=${this._stepSelectChanged} />
+        <label for="${idShowStepSelect}">${this._t('show_step_select')}</label>
       </div>
       <div class="form">
         <input id="${idOnlySelf}" name="only_self" type="checkbox" .checked=${this._config.only_self} @change=${this._selfChanged} />
@@ -1544,6 +1549,17 @@ class TallyListCardEditor extends LitElement {
 
   _removeChanged(ev) {
     this._config = { ...this._config, show_remove: ev.target.checked };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', {
+        detail: { config: this._config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  _stepSelectChanged(ev) {
+    this._config = { ...this._config, show_step_select: ev.target.checked };
     this.dispatchEvent(
       new CustomEvent('config-changed', {
         detail: { config: this._config },


### PR DESCRIPTION
## Summary
- allow toggling step size selection buttons
- document step selection option in English and German READMEs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897914a7510832e882041b0aa3d45b3