### PR TITLE
Display integration missing message

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -567,7 +567,7 @@ class TallyListCard extends LitElement {
     const hasTally =
       (this.hass.services && 'tally_list' in this.hass.services) ||
       Object.keys(states).some(id => id.startsWith('sensor.price_list_'));
-    if (!hasTally) return html`<ha-card>Keine Tally-Entities gefunden.</ha-card>`;
+    if (!hasTally) return html`<ha-card>${this._t('integration_missing')}</ha-card>`;
     if (!this.config) return html`<ha-card>...</ha-card>`;
     let users = this.config.users || this._autoUsers || [];
     if (users.length === 0) {
@@ -1836,7 +1836,7 @@ class TallyDueRankingCard extends LitElement {
     const hasTally =
       (this.hass.services && 'tally_list' in this.hass.services) ||
       Object.keys(states).some(id => id.startsWith('sensor.price_list_'));
-    if (!hasTally) return html`<ha-card>Keine Tally-Entities gefunden.</ha-card>`;
+    if (!hasTally) return html`<ha-card>${this._t('integration_missing')}</ha-card>`;
     if (!this.config) return html`<ha-card>...</ha-card>`;
     let users = this.config.users || this._autoUsers || [];
     if (users.length === 0) {


### PR DESCRIPTION
## Summary
- Use existing `integration_missing` translation when tally_list integration or sensors are absent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897963359a8832eb7bc13f819e90f8f