### PR TITLE
refactor: consolidate utility helpers

### DIFF
--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
+import { translate, fireEvent } from './tally-list-utils.js';
 const CARD_VERSION = '09.08.2025';
 
 const TL_STRINGS = {
@@ -54,26 +55,8 @@ const TL_STRINGS = {
   },
 };
 
-function detectLang(hass, override = 'auto') {
-  if (override && override !== 'auto') return override;
-  const lang =
-    hass?.language || hass?.locale?.language || navigator.language || 'en';
-  return lang.toLowerCase().startsWith('de') ? 'de' : 'en';
-}
-
 function t(hass, override, key) {
-  const lang = detectLang(hass, override);
-  return TL_STRINGS[lang][key] || TL_STRINGS.en[key] || key;
-}
-
-function fireEvent(node, type, detail = {}, options = {}) {
-  node.dispatchEvent(
-    new CustomEvent(type, {
-      detail,
-      bubbles: options.bubbles ?? true,
-      composed: options.composed ?? true,
-    })
-  );
+  return translate(hass, override, TL_STRINGS, key);
 }
 
 class TallyListCardEditor extends LitElement {

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1,6 +1,7 @@
 // Tally List Card
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
 import { repeat } from 'https://unpkg.com/lit/directives/repeat.js?module';
+import { detectLang, translate, fireEvent } from './tally-list-utils.js';
 const CARD_VERSION = '09.08.2025';
 
 const TL_STRINGS = {
@@ -127,26 +128,8 @@ const TL_STRINGS = {
   },
 };
 
-function detectLang(hass, override = 'auto') {
-  if (override && override !== 'auto') return override;
-  const lang =
-    hass?.language || hass?.locale?.language || navigator.language || 'en';
-  return lang.toLowerCase().startsWith('de') ? 'de' : 'en';
-}
-
 function t(hass, override, key) {
-  const lang = detectLang(hass, override);
-  return TL_STRINGS[lang][key] || TL_STRINGS.en[key] || key;
-}
-
-function fireEvent(node, type, detail = {}, options = {}) {
-  node.dispatchEvent(
-    new CustomEvent(type, {
-      detail,
-      bubbles: options.bubbles ?? true,
-      composed: options.composed ?? true,
-    })
-  );
+  return translate(hass, override, TL_STRINGS, key);
 }
 
 function relevantStatesChanged(newHass, oldHass, entities) {
@@ -157,9 +140,7 @@ function relevantStatesChanged(newHass, oldHass, entities) {
   return false;
 }
 
-const navLang = (navigator.language || '').toLowerCase().startsWith('de')
-  ? 'de'
-  : 'en';
+const navLang = detectLang();
 window.customCards = window.customCards || [];
 window.customCards.push({
   type: 'tally-list-card',

--- a/tally-list-utils.js
+++ b/tally-list-utils.js
@@ -1,0 +1,20 @@
+export function detectLang(hass, override = 'auto') {
+  if (override && override !== 'auto') return override;
+  const lang = hass?.language || hass?.locale?.language || navigator.language || 'en';
+  return lang.toLowerCase().startsWith('de') ? 'de' : 'en';
+}
+
+export function translate(hass, override, strings, key) {
+  const lang = detectLang(hass, override);
+  return strings[lang]?.[key] ?? strings.en?.[key] ?? key;
+}
+
+export function fireEvent(node, type, detail = {}, options = {}) {
+  node.dispatchEvent(
+    new CustomEvent(type, {
+      detail,
+      bubbles: options.bubbles ?? true,
+      composed: options.composed ?? true,
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- centralize detectLang, translate, and fireEvent helpers
- reuse shared helpers in card and editor implementations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979f1705c8832e9367960077e5a60a