### PR TITLE
Add free drinks card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -13,15 +13,17 @@ Eine Lovelace-Karte für Home Assistant, die Getränkezähler pro Nutzer anzeigt
 ### Über HACS
 1. Dieses Repository in HACS als **Custom Repository** (Kategorie **Lovelace**) hinzufügen.
 2. **Tally List Card** aus dem HACS‑Store installieren.
-3. HACS hält die Karte aktuell.
+3. HACS hält die Dateien aktuell. Die Freigetränke-Karte ist automatisch enthalten und benötigt keine zusätzliche Ressource.
 
 ### Manuell
 1. `tally-list-card.js` in das `www`‑Verzeichnis von Home Assistant kopieren.
-2. Folgende Ressource in Lovelace eintragen:
+2. Folgende Ressourcen in Lovelace eintragen:
 ```yaml
 - url: /local/tally-list-card.js
   type: module
 ```
+
+Die Freigetränke-Karte wird automatisch geladen und benötigt keine separate Ressource.
 
 ### In Lovelace einbinden
 Nach dem Hinzufügen der Ressource das Dashboard öffnen, **Karte hinzufügen** wählen und **Tally List Card** auswählen. Der Editor erlaubt die Konfiguration ohne YAML.
@@ -79,4 +81,18 @@ Optionen:
 * **hide_free** – Nutzer ohne offenen Betrag ausblenden.
 * **show_copy** – Schaltfläche **Tabelle kopieren** anzeigen.
 * **show_step_select** – Auswahl der Schrittweiten anzeigen.
+
+## Freigetränke-Karte
+
+Bucht Freigetränke mit Pflichtkommentar. Zähler werden lokal gepuffert, bis sie abgeschickt werden.
+
+```yaml
+type: custom:tally-list-free-drinks-card
+```
+
+Optionen:
+
+* **user_mode** – `auto` (Standard) zeigt eine Nutzerauswahl, `fixed` nutzt den angemeldeten Nutzer.
+* **show_prices** – Preise anzeigen (`true` standardmäßig).
+* **sensor_refresh_after_submit** – Sensoren nach dem Abschicken aktualisieren.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Lovelace card for Home Assistant that displays drink tallies per user and allo
 ### Via HACS
 1. Add this repository as a **Custom Repository** in HACS (category **Lovelace**).
 2. Install **Tally List Card** from the HACS store.
-3. HACS keeps the card up to date.
+3. HACS keeps the files up to date. The Free Drinks Card is included automatically and requires no extra resource.
 
 ### Manual
 1. Copy `tally-list-card.js` to your Home Assistant `www` directory.
@@ -22,6 +22,8 @@ A Lovelace card for Home Assistant that displays drink tallies per user and allo
 - url: /local/tally-list-card.js
   type: module
 ```
+
+The Free Drinks Card is loaded automatically and needs no separate resource.
 
 ### Add to Lovelace
 After the resource is available, open the dashboard, choose **Add Card**, and select **Tally List Card**. The editor lets you configure options without YAML.
@@ -80,4 +82,18 @@ Options:
 * **hide_free** – Hide users who owe nothing.
 * **show_copy** – Show the "Tabelle kopieren" button.
 * **show_step_select** – Show buttons to select the step size.
+
+## Free Drinks Card
+
+Book free drinks with a mandatory comment. Counts are kept locally until submitted.
+
+```yaml
+type: custom:tally-list-free-drinks-card
+```
+
+Options:
+
+* **user_mode** – `auto` (default) shows a user selector, `fixed` uses the logged-in user.
+* **show_prices** – Display drink prices (`true` by default).
+* **sensor_refresh_after_submit** – Refresh drink sensors after submission.
 


### PR DESCRIPTION
## Summary
- integrate touchscreen-friendly user chips and remove search from free drinks card
- fix free drink submission and enable visual editor support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68987ed62660832e8c748b53f5accee1