### PR TITLE
Fix drink sensor parsing for names with spaces

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -895,12 +895,8 @@ class TallyListCard extends LitElement {
         const drinks = {};
         const prefix = `sensor.${slug}_`;
         for (const [e2] of Object.entries(states)) {
-          const m2 =
-            e2.startsWith(prefix) &&
-            e2.endsWith('_count') &&
-            e2.match(/^sensor\.[a-z0-9_]+_(.+)_count$/);
-          if (m2) {
-            const drink = m2[1];
+          if (e2.startsWith(prefix) && e2.endsWith('_count')) {
+            const drink = e2.slice(prefix.length, -6);
             drinks[drink] = e2;
           }
         }
@@ -2013,9 +2009,8 @@ class TallyDueRankingCard extends LitElement {
         const drinks = {};
         const prefix = `sensor.${slug}_`;
         for (const [e2] of Object.entries(states)) {
-          const m2 = e2.startsWith(prefix) && e2.endsWith('_count') && e2.match(/^sensor\.[a-z0-9_]+_([^_]+)_count$/);
-          if (m2) {
-            const drink = m2[1];
+          if (e2.startsWith(prefix) && e2.endsWith('_count')) {
+            const drink = e2.slice(prefix.length, -6);
             drinks[drink] = e2;
           }
         }
@@ -2643,12 +2638,8 @@ class TallyListFreeDrinksCard extends LitElement {
         const drinks = {};
         const prefix = `sensor.${slug}_`;
         for (const [e2] of Object.entries(states)) {
-          const m2 =
-            e2.startsWith(prefix) &&
-            e2.endsWith('_count') &&
-            e2.match(/^sensor\.[a-z0-9_]+_(.+)_count$/);
-          if (m2) {
-            const drink = m2[1];
+          if (e2.startsWith(prefix) && e2.endsWith('_count')) {
+            const drink = e2.slice(prefix.length, -6);
             drinks[drink] = e2;
           }
         }


### PR DESCRIPTION
## Summary
- handle drink sensors with spaces by slicing sensor IDs instead of regex in user gathering logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898979b6af4832ead585893b32d73e3