### PR TITLE
Fix drink sensor parsing for names with spaces

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -532,7 +532,7 @@ class TallyListCard extends LitElement {
         const cost = count * price;
         total += cost;
         const costStr = this._formatPrice(cost) + ` ${this._currency}`;
-        rows.push({ drink, entity, count, priceStr, costStr, isAvailable, display: drink.charAt(0).toUpperCase() + drink.slice(1) });
+        rows.push({ drink, entity, count, priceStr, costStr, isAvailable, display: this._unslugify(drink) });
       });
 
     if (user.amount_due_entity) deps.add(user.amount_due_entity);
@@ -706,7 +706,7 @@ class TallyListCard extends LitElement {
                             drinks,
                             d => d,
                             d => html`<option value="${d}">
-                                ${d.charAt(0).toUpperCase() + d.slice(1)}
+                                ${this._unslugify(d)}
                               </option>`
                           )}
                         </select>
@@ -763,7 +763,7 @@ class TallyListCard extends LitElement {
       this._disabled = false;
       this.requestUpdate();
     }, delay);
-    const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
+    const displayDrink = this._unslugify(drink);
 
     const users = this.config.users || this._autoUsers || [];
     const user = users.find(u => (u.name || u.slug) === this.selectedUser);
@@ -819,7 +819,7 @@ class TallyListCard extends LitElement {
       this.requestUpdate();
     }, delay);
 
-    const displayDrink = drink.charAt(0).toUpperCase() + drink.slice(1);
+    const displayDrink = this._unslugify(drink);
 
     if (entity) {
       const base = this._optimisticCounts[entity] ?? count;
@@ -893,14 +893,10 @@ class TallyListCard extends LitElement {
           .replace(' Amount Due', '')
           .replace(' Offener Betrag', '');
         const drinks = {};
-        const prefix = `sensor.${slug}_`;
         for (const [e2] of Object.entries(states)) {
-          const m2 =
-            e2.startsWith(prefix) &&
-            e2.endsWith('_count') &&
-            e2.match(/^sensor\.[a-z0-9_]+_(.+)_count$/);
-          if (m2) {
-            const drink = m2[1];
+          const m2 = e2.match(/^sensor\.([a-z0-9_]+)_(.+)_count$/);
+          if (m2 && m2[1] === slug) {
+            const drink = m2[2];
             drinks[drink] = e2;
           }
         }
@@ -1000,6 +996,13 @@ class TallyListCard extends LitElement {
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '_')
       .replace(/^_+|_+$/g, '');
+  }
+
+  _unslugify(str) {
+    if (!str) return '';
+    return str
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, c => c.toUpperCase());
   }
 
   _currentPersonNames() {
@@ -2011,11 +2014,10 @@ class TallyDueRankingCard extends LitElement {
           .replace(' Amount Due', '')
           .replace(' Offener Betrag', '');
         const drinks = {};
-        const prefix = `sensor.${slug}_`;
         for (const [e2] of Object.entries(states)) {
-          const m2 = e2.startsWith(prefix) && e2.endsWith('_count') && e2.match(/^sensor\.[a-z0-9_]+_([^_]+)_count$/);
-          if (m2) {
-            const drink = m2[1];
+          const m2 = e2.match(/^sensor\.([a-z0-9_]+)_(.+)_count$/);
+          if (m2 && m2[1] === slug) {
+            const drink = m2[2];
             drinks[drink] = e2;
           }
         }
@@ -2641,14 +2643,10 @@ class TallyListFreeDrinksCard extends LitElement {
           .replace(' Amount Due', '')
           .replace(' Offener Betrag', '');
         const drinks = {};
-        const prefix = `sensor.${slug}_`;
         for (const [e2] of Object.entries(states)) {
-          const m2 =
-            e2.startsWith(prefix) &&
-            e2.endsWith('_count') &&
-            e2.match(/^sensor\.[a-z0-9_]+_(.+)_count$/);
-          if (m2) {
-            const drink = m2[1];
+          const m2 = e2.match(/^sensor\.([a-z0-9_]+)_(.+)_count$/);
+          if (m2 && m2[1] === slug) {
+            const drink = m2[2];
             drinks[drink] = e2;
           }
         }


### PR DESCRIPTION
## Summary
- convert drink slugs with underscores into display names when rendering and booking to support drinks like "Bier Limo"
- match drink count sensors to the exact user slug to prevent duplicate drinks for similarly named users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898979b6af4832ead585893b32d73e3