### PR TITLE
feat: tabbed user selection for free drinks card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -95,4 +95,6 @@ Optionen:
 * **user_mode** – `auto` (Standard) zeigt eine Nutzerauswahl, `fixed` nutzt den angemeldeten Nutzer.
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
 * **sensor_refresh_after_submit** – Sensoren nach dem Abschicken aktualisieren.
+* **user_selector** – `list` (Standard) oder `tabs` für nach Buchstaben gruppierte Nutzer.
+* **tabs** – Optionen für `user_selector: tabs` (z. B. `mode`, `grouped_breaks`, `show_all_tab`).
 

--- a/README.md
+++ b/README.md
@@ -96,4 +96,6 @@ Options:
 * **user_mode** – `auto` (default) shows a user selector, `fixed` uses the logged-in user.
 * **show_prices** – Display drink prices (`true` by default).
 * **sensor_refresh_after_submit** – Refresh drink sensors after submission.
+* **user_selector** – `list` (default) or `tabs` to group users by first letter.
+* **tabs** – Options for `user_selector: tabs` (e.g. `mode`, `grouped_breaks`, `show_all_tab`).
 


### PR DESCRIPTION
## Summary
- add tab and list user selector options to free drinks card
- allow configuring tab grouping in card editor
- document new options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898977acf98832e9da014c22bef5b28