### PR TITLE
chore: bump version to 10.08.2025

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "09.08.2025",
+  "version": "10.08.2025",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
 import { translate, fireEvent } from './tally-list-card.js';
-const CARD_VERSION = '09.08.2025';
+const CARD_VERSION = '10.08.2025';
 
 const TL_STRINGS = {
   en: {

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -23,7 +23,7 @@ export function fireEvent(node, type, detail = {}, options = {}) {
     })
   );
 }
-const CARD_VERSION = '09.08.2025';
+const CARD_VERSION = '10.08.2025';
 
 const TL_STRINGS = {
   en: {


### PR DESCRIPTION
## Summary
- update version to 10.08.2025 in package and card files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68989c040620832e9f4386f2891f54e7