### PR TITLE
Add debug submenu to Free Drinks Card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -92,7 +92,7 @@ type: custom:tally-list-free-drinks-card
 
 Optionen:
 
-* **user_mode** – `auto` (Standard) zeigt eine Nutzerauswahl, `fixed` nutzt den angemeldeten Nutzer.
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
-* **sensor_refresh_after_submit** – Sensoren nach dem Abschicken aktualisieren.
+* **Sprache** – Erzwinge **Auto**, **Deutsch** oder **Englisch**.
+* **Version** – Zeigt die installierte Version an.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ type: custom:tally-list-free-drinks-card
 
 Options:
 
-* **user_mode** – `auto` (default) shows a user selector, `fixed` uses the logged-in user.
 * **show_prices** – Display drink prices (`true` by default).
-* **sensor_refresh_after_submit** – Refresh drink sensors after submission.
+* **Language** – Force **Auto**, **Deutsch**, or **English**.
+* **Version** – Display the installed version.
 


### PR DESCRIPTION
## Summary
- add Debug submenu with language selection to Free Drinks Card
- remove obsolete `user_mode` and `sensor_refresh_after_submit` options
- document new language option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a1a13178832eaac75bc385866650