### PR TITLE
refactor: simplify free drinks card options

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -92,9 +92,7 @@ type: custom:tally-list-free-drinks-card
 
 Optionen:
 
-* **user_mode** – `auto` (Standard) zeigt eine Nutzerauswahl, `fixed` nutzt den angemeldeten Nutzer.
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
-* **sensor_refresh_after_submit** – Sensoren nach dem Abschicken aktualisieren.
 * **comment_presets** – Vordefinierte Kommentarpräfixe. Jedes Element hat `label` und optional `require_comment`.
 
 Beispiel:

--- a/README.md
+++ b/README.md
@@ -93,9 +93,7 @@ type: custom:tally-list-free-drinks-card
 
 Options:
 
-* **user_mode** – `auto` (default) shows a user selector, `fixed` uses the logged-in user.
 * **show_prices** – Display drink prices (`true` by default).
-* **sensor_refresh_after_submit** – Refresh drink sensors after submission.
 * **comment_presets** – Predefine comment prefixes. Each entry has a `label` and optional `require_comment`.
 
 Example:


### PR DESCRIPTION
## Summary
- drop user mode and sensor refresh settings from Free Drinks Card
- add Debug submenu with language selector and version display
- update documentation for streamlined configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a3ec3178832ebb5d53041bf0e968