### PR TITLE
Add reset button to free drinks card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -84,7 +84,7 @@ Optionen:
 
 ## Freigetränke-Karte
 
-Bucht Freigetränke mit Pflichtkommentar. Zähler werden lokal gepuffert, bis sie abgeschickt werden.
+Bucht Freigetränke mit Pflichtkommentar. Zähler werden lokal gepuffert, bis sie abgeschickt werden. Mit dem Reset-Button lassen sich alle Zähler zurücksetzen.
 
 ```yaml
 type: custom:tally-list-free-drinks-card

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Options:
 
 ## Free Drinks Card
 
-Book free drinks with a mandatory comment. Counts are kept locally until submitted.
+Book free drinks with a mandatory comment. Counts are kept locally until submitted. Use the reset button to clear all counts.
 
 ```yaml
 type: custom:tally-list-free-drinks-card

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -2447,6 +2447,7 @@ const FD_STRINGS = {
     comment: 'Comment',
     comment_error: 'Please enter at least 3 characters',
     submit: 'Submit',
+    reset: 'Reset',
     drink: 'Drink',
     price: 'Price',
     count: 'Count',
@@ -2468,6 +2469,7 @@ const FD_STRINGS = {
     comment: 'Kommentar',
     comment_error: 'Bitte mindestens 3 Zeichen eingeben',
     submit: 'Abschicken',
+    reset: 'Zurücksetzen',
     drink: 'Getränk',
     price: 'Preis',
     count: 'Zähler',
@@ -3075,6 +3077,10 @@ class TallyListFreeDrinksCard extends LitElement {
     }
   }
 
+  _reset() {
+    this._pending = {};
+  }
+
   render() {
     const allUsers = this.config.users || this._autoUsers || [];
     const prices = this.config.prices || this._autoPrices;
@@ -3166,13 +3172,22 @@ class TallyListFreeDrinksCard extends LitElement {
                 this.config.language,
                 'comment_error'
               )}</div>`}
-          <button
-            class="action-btn submit"
-            ?disabled=${!this._validComment() || this._pendingSum() === 0}
-            @pointerdown=${this._submit}
-          >
-            ${fdT(this.hass, this.config.language, 'submit')}
-          </button>
+          <div class="buttons">
+            <button
+              class="action-btn reset"
+              ?disabled=${this._pendingSum() === 0}
+              @pointerdown=${this._reset}
+            >
+              ${fdT(this.hass, this.config.language, 'reset')}
+            </button>
+            <button
+              class="action-btn submit"
+              ?disabled=${!this._validComment() || this._pendingSum() === 0}
+              @pointerdown=${this._submit}
+            >
+              ${fdT(this.hass, this.config.language, 'submit')}
+            </button>
+          </div>
         </div>
       </ha-card>
     `;
@@ -3323,6 +3338,14 @@ class TallyListFreeDrinksCard extends LitElement {
       flex-direction: column;
       gap: 4px;
     }
+    .footer .buttons {
+      display: flex;
+      gap: 4px;
+    }
+    .footer .buttons .action-btn {
+      flex: 1;
+      width: auto;
+    }
     .footer .preset-select {
       display: flex;
       align-items: center;
@@ -3352,8 +3375,12 @@ class TallyListFreeDrinksCard extends LitElement {
       color: var(--error-color);
       font-size: 0.9em;
     }
+    .footer .reset {
+      background: var(--error-color, #c62828);
+      color: var(--text-primary-color, #fff);
+    }
     .footer .submit {
-      width: 100%;
+      flex: 1;
       background: var(--primary-color);
       color: var(--text-primary-color, #fff);
     }


### PR DESCRIPTION
## Summary
- Add reset button next to submit to clear all counters
- Document reset option in README files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b7612688832e85f9f64af86bbb8d