### PR TITLE
Align free drinks comment field with counter styling

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -3329,11 +3329,16 @@ class TallyListFreeDrinksCard extends LitElement {
       gap: 8px;
     }
     .footer input {
-      height: 44px;
-      padding: 0 8px;
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--primary-text-color);
+      border: none;
+      border-radius: 8px;
+      padding: 6px 10px;
+      width: 100%;
       box-sizing: border-box;
-      border-radius: 12px;
-      border: 1px solid var(--ha-card-border-color);
+    }
+    .footer input::placeholder {
+      color: rgba(255, 255, 255, 0.4);
     }
     .footer select {
       padding: 0 12px;


### PR DESCRIPTION
## Summary
- Style free drink comment input to use the same background and text color as the counter
- Add placeholder color and padding for consistent appearance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ba4a8db0832e93aa9cd0f53ce0c0