### PR TITLE
Align free drinks comment field with counter styling

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -3328,12 +3328,19 @@ class TallyListFreeDrinksCard extends LitElement {
       align-items: center;
       gap: 8px;
     }
-    .footer input {
-      height: 44px;
-      padding: 0 8px;
+    .free-drinks .footer input,
+    .free-drinks .footer textarea {
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--primary-text-color);
+      border: none;
+      border-radius: 8px;
+      padding: 6px 10px;
+      width: 100%;
       box-sizing: border-box;
-      border-radius: 12px;
-      border: 1px solid var(--ha-card-border-color);
+    }
+    .free-drinks .footer input::placeholder,
+    .free-drinks .footer textarea::placeholder {
+      color: rgba(255, 255, 255, 0.4);
     }
     .footer select {
       padding: 0 12px;


### PR DESCRIPTION
## Summary
- Apply counter-matching background, text color, and padding to the free drinks comment field
- Scope styles to the free drinks card and support both input and textarea elements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ba4a8db0832e93aa9cd0f53ce0c0