### PR TITLE
Improve free drinks card spacing

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -3246,6 +3246,7 @@ class TallyListFreeDrinksCard extends LitElement {
     table {
       width: 100%;
       border-collapse: collapse;
+      margin-top: 8px;
     }
     th,
     td {


### PR DESCRIPTION
## Summary
- add top margin to the free drinks table for consistent spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c3b3b0ec832e86b5a028967e8bea