### PR TITLE
feat: add auto-reset timer for free drinks

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -94,6 +94,7 @@ Optionen:
 
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
 * **comment_presets** – Vordefinierte Kommentarpräfixe. Jedes Element hat `label` und optional `require_comment`.
+* **free_drinks_timer_seconds** – Auto-Reset-Timer in Sekunden (`0` = aus).
 
 Beispiel:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Options:
 
 * **show_prices** – Display drink prices (`true` by default).
 * **comment_presets** – Predefine comment prefixes. Each entry has a `label` and optional `require_comment`.
+* **free_drinks_timer_seconds** – Auto-reset timer in seconds (`0` to disable).
 
 Example:
 


### PR DESCRIPTION
## Summary
- add `free_drinks_timer_seconds` config and timer state for free drinks card
- display countdown next to counter header and reset counts when time runs out
- document `free_drinks_timer_seconds` option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c8d72f38832ea9930f13529202b7