### PR TITLE
feat: add auto-reset timer for free drinks

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -94,6 +94,7 @@ Optionen:
 
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
 * **comment_presets** – Vordefinierte Kommentarpräfixe. Jedes Element hat `label` und optional `require_comment`.
+* **free_drinks_timer_seconds** – Auto-Reset-Timer in Sekunden (`0` = aus).
 
 Beispiel:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Options:
 
 * **show_prices** – Display drink prices (`true` by default).
 * **comment_presets** – Predefine comment prefixes. Each entry has a `label` and optional `require_comment`.
+* **free_drinks_timer_seconds** – Auto-reset timer in seconds (`0` to disable).
 
 Example:
 

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -6,6 +6,7 @@ const TL_STRINGS = {
   en: {
     lock_ms: 'Lock duration (ms)',
     max_width: 'Maximum width (px)',
+    free_drinks_timer_seconds: 'Free drinks timer (s)',
     show_remove_menu: 'Show remove menu',
     only_self: 'Only show own user even for admins',
     show_step_select: 'Show step selection',
@@ -31,6 +32,7 @@ const TL_STRINGS = {
   de: {
     lock_ms: 'Sperrzeit (ms)',
     max_width: 'Maximale Breite (px)',
+    free_drinks_timer_seconds: 'Freigetränke-Timer (s)',
     show_remove_menu: 'Entfernen-Menü anzeigen',
     only_self: 'Trotz Admin nur eigenen Nutzer anzeigen',
     show_step_select: 'Schrittweiten-Auswahl anzeigen',
@@ -78,6 +80,7 @@ class TallyListCardEditor extends LitElement {
     this._config = {
       lock_ms: 400,
       max_width: '500px',
+      free_drinks_timer_seconds: 0,
       show_remove: true,
       only_self: false,
       show_step_select: true,
@@ -112,6 +115,14 @@ class TallyListCardEditor extends LitElement {
           type="number"
           .value=${(this._config.max_width ?? '').replace(/px$/, '')}
           @input=${this._widthChanged}
+        />
+      </div>
+      <div class="form">
+        <label>${this._t('free_drinks_timer_seconds')}</label>
+        <input
+          type="number"
+          .value=${this._config.free_drinks_timer_seconds}
+          @input=${this._fdTimerChanged}
         />
       </div>
       <div class="form">
@@ -278,6 +289,15 @@ class TallyListCardEditor extends LitElement {
     this._config = {
       ...this._config,
       grid: { ...this._config.grid, columns },
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _fdTimerChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = {
+      ...this._config,
+      free_drinks_timer_seconds: isNaN(value) ? 0 : value,
     };
     fireEvent(this, 'config-changed', { config: this._config });
   }

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -46,6 +46,7 @@ const TL_STRINGS = {
     amount_due: 'Amount due',
     lock_ms: 'Lock duration (ms)',
     max_width: 'Maximum width (px)',
+    free_drinks_timer_seconds: 'Free drinks timer (s)',
     show_remove_menu: 'Show remove menu',
     only_self: 'Only show own user even for admins',
     show_all_users: 'Show all users',
@@ -107,6 +108,7 @@ const TL_STRINGS = {
     amount_due: 'Zu zahlen',
     lock_ms: 'Sperrzeit (ms)',
     max_width: 'Maximale Breite (px)',
+    free_drinks_timer_seconds: 'Freigetränke-Timer (s)',
     show_remove_menu: 'Entfernen-Menü anzeigen',
     only_self: 'Trotz Admin nur eigenen Nutzer anzeigen',
     show_all_users: 'Alle Nutzer anzeigen',
@@ -2526,6 +2528,7 @@ class TallyListFreeDrinksCardEditor extends LitElement {
     const grid = { columns: 0, ...(config?.grid || {}) };
     this._config = {
       show_prices: true,
+      free_drinks_timer_seconds: 0,
       language: 'auto',
       user_selector: 'list',
       ...(config || {}),
@@ -2545,6 +2548,7 @@ class TallyListFreeDrinksCardEditor extends LitElement {
     const idGroupedBreaks = this._fid('grouped-breaks');
     const idShowAllTab = this._fid('show-all-tab');
     const idGridColumns = this._fid('grid-columns');
+    const idFdTimer = this._fid('fd-timer');
     return html`
       <div class="form">
         <input
@@ -2568,6 +2572,15 @@ class TallyListFreeDrinksCardEditor extends LitElement {
             .map((p) => `${p.label}${p.require_comment ? '*' : ''}`)
             .join('\n')}
         ></textarea>
+      </div>
+      <div class="form">
+        <label for="${idFdTimer}">${t(this.hass, this._config.language, 'free_drinks_timer_seconds')}</label>
+        <input
+          id="${idFdTimer}"
+          type="number"
+          .value=${this._config.free_drinks_timer_seconds}
+          @input=${this._fdTimerChanged}
+        />
       </div>
       <div class="form">
         <label for="${idUserSelector}">${t(this.hass, this._config.language, 'user_selector')}</label>
@@ -2685,6 +2698,15 @@ class TallyListFreeDrinksCardEditor extends LitElement {
     fireEvent(this, 'config-changed', { config: this._config });
   }
 
+  _fdTimerChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = {
+      ...this._config,
+      free_drinks_timer_seconds: isNaN(value) ? 0 : value,
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
   _fid(s) {
     return `fde-${s}`;
   }
@@ -2756,6 +2778,8 @@ class TallyListFreeDrinksCard extends LitElement {
     _tabs: { state: true },
     _visibleUsers: { state: true },
     _currentTab: { state: true },
+    _fdCountdownLeft: { type: Number },
+    _fdTimerId: { type: Number },
   };
 
   _fmtCache = new Map();
@@ -2773,6 +2797,8 @@ class TallyListFreeDrinksCard extends LitElement {
     this._tabs = [];
     this._visibleUsers = [];
     this._currentTab = 'all';
+    this._fdCountdownLeft = 0;
+    this._fdTimerId = 0;
     this._buckets = new Map();
     this._sortedUsers = [];
     this._usersKey = '';
@@ -2803,6 +2829,9 @@ class TallyListFreeDrinksCard extends LitElement {
       tabs,
       grid,
     };
+    this.config.free_drinks_timer_seconds = Number(
+      config?.free_drinks_timer_seconds ?? 0
+    );
     if (!this._commentType && this.config.comment_presets?.length) {
       this._commentType = this.config.comment_presets[0].label;
     }
@@ -2814,6 +2843,11 @@ class TallyListFreeDrinksCard extends LitElement {
 
   firstUpdated() {
     if (!this.selectedUserId) this.selectedUserId = this.hass?.user?.id || '';
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback?.();
+    this._fdStopCountdown();
   }
 
   get _isAdmin() {
@@ -2965,6 +2999,7 @@ class TallyListFreeDrinksCard extends LitElement {
     const drink = ev.currentTarget.dataset.drink;
     const cur = this._pending[drink] || 0;
     this._pending = { ...this._pending, [drink]: cur + 1 };
+    this._fdStartOrResetCountdown();
   }
 
   _dec(ev) {
@@ -2972,6 +3007,59 @@ class TallyListFreeDrinksCard extends LitElement {
     const cur = this._pending[drink] || 0;
     const next = Math.max(0, cur - 1);
     this._pending = { ...this._pending, [drink]: next };
+    this._fdStartOrResetCountdown();
+  }
+
+  _fdStartOrResetCountdown() {
+    const total = Number(this.config?.free_drinks_timer_seconds || 0);
+    if (!total) return;
+    this._fdCountdownLeft = total;
+    if (this._fdTimerId) clearInterval(this._fdTimerId);
+    this._fdTimerId = setInterval(() => {
+      this._fdCountdownLeft = Math.max(0, (this._fdCountdownLeft || 0) - 1);
+      this.requestUpdate('_fdCountdownLeft');
+      if (this._fdCountdownLeft === 0) {
+        this._fdStopCountdown();
+        this._fdResetAllCountersToZero();
+      }
+    }, 1000);
+  }
+
+  _fdStopCountdown() {
+    if (this._fdTimerId) {
+      clearInterval(this._fdTimerId);
+      this._fdTimerId = 0;
+    }
+  }
+
+  _fdFormatTime(sec) {
+    const s = Math.max(0, Number(sec || 0));
+    const m = Math.floor(s / 60);
+    const r = s % 60;
+    return `${String(m).padStart(2, '0')}:${String(r).padStart(2, '0')}`;
+  }
+
+  _fdResetAllCountersToZero() {
+    this._pending = {};
+    this.requestUpdate('_pending');
+  }
+
+  _renderFdHeader() {
+    const enabled = Number(this.config?.free_drinks_timer_seconds || 0) > 0;
+    const running = !!this._fdTimerId;
+    return html`
+      <div class="fd-header">
+        <span>${fdT(this.hass, this.config.language, 'count')}</span>
+        ${enabled && running
+          ? html`<span
+              class="fd-countdown"
+              aria-label="Auto-Reset in ${this._fdFormatTime(this._fdCountdownLeft)}"
+            >
+              ${this._fdFormatTime(this._fdCountdownLeft)}
+            </span>`
+          : ''}
+      </div>
+    `;
   }
 
   _onComment(ev) {
@@ -3056,6 +3144,9 @@ class TallyListFreeDrinksCard extends LitElement {
         });
       }
       this._pending = {};
+      this._fdStopCountdown();
+      this._fdCountdownLeft = 0;
+      this.requestUpdate('_fdCountdownLeft');
       this._comment = '';
       if (this.config.comment_presets?.length) {
         this._commentType = this.config.comment_presets[0].label;
@@ -3081,6 +3172,9 @@ class TallyListFreeDrinksCard extends LitElement {
 
   _reset() {
     this._pending = {};
+    this._fdStopCountdown();
+    this._fdCountdownLeft = 0;
+    this.requestUpdate('_fdCountdownLeft');
   }
 
   render() {
@@ -3131,7 +3225,7 @@ class TallyListFreeDrinksCard extends LitElement {
             <tr>
               <th>${fdT(this.hass, this.config.language, 'drink')}</th>
               ${showPrices ? html`<th>${fdT(this.hass, this.config.language, 'price')}</th>` : ''}
-              <th>${fdT(this.hass, this.config.language, 'count')}</th>
+              <th>${this._renderFdHeader()}</th>
             </tr>
           </thead>
           <tbody>
@@ -3263,6 +3357,20 @@ class TallyListFreeDrinksCard extends LitElement {
       display: flex;
       align-items: center;
       justify-content: center;
+    }
+    .fd-header {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .fd-countdown {
+      font-variant-numeric: tabular-nums;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: var(--chip-background-color, rgba(255,255,255,0.08));
+      color: var(--primary-text-color);
+      line-height: 1.6;
+      font-size: 0.9em;
     }
     .action-btn {
       display: inline-flex;


### PR DESCRIPTION
## Summary
- add `free_drinks_timer_seconds` config and timer state for free drinks card
- display countdown next to counter header and reset counts when time runs out
- document `free_drinks_timer_seconds` option
- expose timer setting in card editors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c8d72f38832ea9930f13529202b7