### PR TITLE
feat: add free drink limits

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -95,6 +95,8 @@ Optionen:
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
 * **comment_presets** – Vordefinierte Kommentarpräfixe. Jedes Element hat `label` und optional `require_comment`.
 * **free_drinks_timer_seconds** – Auto-Reset-Timer in Sekunden (`0` = aus).
+* **free_drinks_per_item_limit** – Limit je Getränk (`0` = aus).
+* **free_drinks_total_limit** – Gesamtlimit (`0` = aus).
 
 Beispiel:
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Options:
 * **show_prices** – Display drink prices (`true` by default).
 * **comment_presets** – Predefine comment prefixes. Each entry has a `label` and optional `require_comment`.
 * **free_drinks_timer_seconds** – Auto-reset timer in seconds (`0` to disable).
+* **free_drinks_per_item_limit** – Maximum free drinks per item (`0` to disable).
+* **free_drinks_total_limit** – Maximum free drinks overall (`0` to disable).
 
 Example:
 

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -7,6 +7,8 @@ const TL_STRINGS = {
     lock_ms: 'Lock duration (ms)',
     max_width: 'Maximum width (px)',
     free_drinks_timer_seconds: 'Free drinks timer (s)',
+    free_drinks_per_item_limit: 'Free drinks per item limit',
+    free_drinks_total_limit: 'Free drinks total limit',
     show_remove_menu: 'Show remove menu',
     only_self: 'Only show own user even for admins',
     show_step_select: 'Show step selection',
@@ -33,6 +35,8 @@ const TL_STRINGS = {
     lock_ms: 'Sperrzeit (ms)',
     max_width: 'Maximale Breite (px)',
     free_drinks_timer_seconds: 'Freigetränke-Timer (s)',
+    free_drinks_per_item_limit: 'Limit je Getränk (0 = aus)',
+    free_drinks_total_limit: 'Gesamtlimit (0 = aus)',
     show_remove_menu: 'Entfernen-Menü anzeigen',
     only_self: 'Trotz Admin nur eigenen Nutzer anzeigen',
     show_step_select: 'Schrittweiten-Auswahl anzeigen',
@@ -81,6 +85,8 @@ class TallyListCardEditor extends LitElement {
       lock_ms: 400,
       max_width: '500px',
       free_drinks_timer_seconds: 0,
+      free_drinks_per_item_limit: 0,
+      free_drinks_total_limit: 0,
       show_remove: true,
       only_self: false,
       show_step_select: true,
@@ -123,6 +129,22 @@ class TallyListCardEditor extends LitElement {
           type="number"
           .value=${this._config.free_drinks_timer_seconds}
           @input=${this._fdTimerChanged}
+        />
+      </div>
+      <div class="form">
+        <label>${this._t('free_drinks_per_item_limit')}</label>
+        <input
+          type="number"
+          .value=${this._config.free_drinks_per_item_limit}
+          @input=${this._fdPerItemChanged}
+        />
+      </div>
+      <div class="form">
+        <label>${this._t('free_drinks_total_limit')}</label>
+        <input
+          type="number"
+          .value=${this._config.free_drinks_total_limit}
+          @input=${this._fdTotalChanged}
         />
       </div>
       <div class="form">
@@ -298,6 +320,24 @@ class TallyListCardEditor extends LitElement {
     this._config = {
       ...this._config,
       free_drinks_timer_seconds: isNaN(value) ? 0 : value,
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _fdPerItemChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = {
+      ...this._config,
+      free_drinks_per_item_limit: isNaN(value) ? 0 : value,
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _fdTotalChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = {
+      ...this._config,
+      free_drinks_total_limit: isNaN(value) ? 0 : value,
     };
     fireEvent(this, 'config-changed', { config: this._config });
   }

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -2771,7 +2771,7 @@ class TallyListFreeDrinksCard extends LitElement {
     _autoUsers: { state: true },
     _autoPrices: { state: true },
     _currency: { state: true },
-    _pending: { state: true },
+    _freeDrinkCounts: { state: true },
     _comment: { state: true },
     _drinkNames: { state: true },
     _commentType: { state: true },
@@ -2790,7 +2790,7 @@ class TallyListFreeDrinksCard extends LitElement {
     this._autoUsers = [];
     this._autoPrices = {};
     this._currency = '';
-    this._pending = {};
+    this._freeDrinkCounts = {};
     this._comment = '';
     this._drinkNames = {};
     this._commentType = '';
@@ -2832,9 +2832,33 @@ class TallyListFreeDrinksCard extends LitElement {
     this.config.free_drinks_timer_seconds = Number(
       config?.free_drinks_timer_seconds ?? 0
     );
+    this.config.free_drinks_per_item_limit = Number(
+      config?.free_drinks_per_item_limit ?? 0
+    );
+    this.config.free_drinks_total_limit = Number(
+      config?.free_drinks_total_limit ?? 0
+    );
     if (!this._commentType && this.config.comment_presets?.length) {
       this._commentType = this.config.comment_presets[0].label;
     }
+  }
+
+  get _perItemCap() {
+    return Math.max(0, Number(this.config?.free_drinks_per_item_limit || 0));
+  }
+
+  get _totalCap() {
+    return Math.max(0, Number(this.config?.free_drinks_total_limit || 0));
+  }
+
+  _getTotalCount() {
+    let sum = 0;
+    if (this._freeDrinkCounts) {
+      for (const k of Object.keys(this._freeDrinkCounts)) {
+        sum += Number(this._freeDrinkCounts[k] || 0);
+      }
+    }
+    return sum;
   }
 
   getCardSize() {
@@ -2995,19 +3019,29 @@ class TallyListFreeDrinksCard extends LitElement {
     );
   }
 
-  _inc(ev) {
-    const drink = ev.currentTarget.dataset.drink;
-    const cur = this._pending[drink] || 0;
-    this._pending = { ...this._pending, [drink]: cur + 1 };
-    this._fdStartOrResetCountdown();
+  _fdInc(drinkId) {
+    const perCap = this._perItemCap;
+    const totalCap = this._totalCap;
+
+    const current = Number(this._freeDrinkCounts?.[drinkId] || 0);
+    const total = this._getTotalCount();
+
+    if (perCap > 0 && current >= perCap) return;
+    if (totalCap > 0 && total >= totalCap) return;
+
+    this._freeDrinkCounts[drinkId] = current + 1;
+    this.requestUpdate();
+    this._fdStartOrResetCountdown?.();
   }
 
-  _dec(ev) {
-    const drink = ev.currentTarget.dataset.drink;
-    const cur = this._pending[drink] || 0;
-    const next = Math.max(0, cur - 1);
-    this._pending = { ...this._pending, [drink]: next };
-    this._fdStartOrResetCountdown();
+  _fdDec(drinkId) {
+    const current = Number(this._freeDrinkCounts?.[drinkId] || 0);
+    const next = Math.max(0, current - 1);
+    if (next === current) return;
+
+    this._freeDrinkCounts[drinkId] = next;
+    this.requestUpdate();
+    this._fdStartOrResetCountdown?.();
   }
 
   _fdStartOrResetCountdown() {
@@ -3040,23 +3074,43 @@ class TallyListFreeDrinksCard extends LitElement {
   }
 
   _fdResetAllCountersToZero() {
-    this._pending = {};
-    this.requestUpdate('_pending');
+    this._freeDrinkCounts = {};
+    this.requestUpdate('_freeDrinkCounts');
+  }
+
+  _fdValidateLimitsOrThrow() {
+    const total = this._getTotalCount();
+    if (this._totalCap > 0 && total > this._totalCap)
+      throw new Error('Gesamtlimit überschritten');
+    if (this._perItemCap > 0) {
+      for (const k of Object.keys(this._freeDrinkCounts ?? {})) {
+        const v = Number(this._freeDrinkCounts[k] || 0);
+        if (v > this._perItemCap)
+          throw new Error(`Limit je Getränk überschritten (${k})`);
+      }
+    }
   }
 
   _renderFdHeader() {
-    const enabled = Number(this.config?.free_drinks_timer_seconds || 0) > 0;
+    const enabledTimer = Number(this.config?.free_drinks_timer_seconds || 0) > 0;
     const running = !!this._fdTimerId;
+
+    const totalCap = this._totalCap;
+    const rest = totalCap > 0 ? Math.max(0, totalCap - this._getTotalCount()) : null;
+
     return html`
       <div class="fd-header">
         <span>${fdT(this.hass, this.config.language, 'count')}</span>
-        ${enabled && running
+        ${enabledTimer && running
           ? html`<span
               class="fd-countdown"
               aria-label="Auto-Reset in ${this._fdFormatTime(this._fdCountdownLeft)}"
             >
               ${this._fdFormatTime(this._fdCountdownLeft)}
             </span>`
+          : ''}
+        ${totalCap > 0
+          ? html`<span class="fd-rest" title="Verbleibend gesamt">${rest}</span>`
           : ''}
       </div>
     `;
@@ -3082,9 +3136,6 @@ class TallyListFreeDrinksCard extends LitElement {
     return trimmed.length >= 3 && trimmed === this._comment;
   }
 
-  _pendingSum() {
-    return Object.values(this._pending).reduce((a, b) => a + b, 0);
-  }
 
   _formatPrice(value) {
     const locale = this.hass?.locale;
@@ -3115,7 +3166,7 @@ class TallyListFreeDrinksCard extends LitElement {
   }
 
   async _submit() {
-    if (!this._validComment() || this._pendingSum() === 0) return;
+    if (!this._validComment() || this._getTotalCount() === 0) return;
     const extra = this._comment.trim();
     const comment = this._commentType
       ? extra
@@ -3128,8 +3179,9 @@ class TallyListFreeDrinksCard extends LitElement {
       (u) => u.user_id === uid || u.slug === uid || u.name === uid
     );
     const user = uObj?.name || uid;
-    const drinks = Object.entries(this._pending).filter(([d, c]) => c > 0);
+    const drinks = Object.entries(this._freeDrinkCounts).filter(([d, c]) => c > 0);
     try {
+      this._fdValidateLimitsOrThrow();
       for (const [drink, count] of drinks) {
         const drinkName =
           (this._drinkNames[drink] || drink)
@@ -3143,7 +3195,7 @@ class TallyListFreeDrinksCard extends LitElement {
           comment,
         });
       }
-      this._pending = {};
+      this._fdResetAllCountersToZero();
       this._fdStopCountdown();
       this._fdCountdownLeft = 0;
       this.requestUpdate('_fdCountdownLeft');
@@ -3159,6 +3211,7 @@ class TallyListFreeDrinksCard extends LitElement {
         })
       );
     } catch (err) {
+      console.warn('[free-drinks] submit blocked:', err);
       const code = err?.error?.code || err?.code || err?.message || err;
       this.dispatchEvent(
         new CustomEvent('hass-notification', {
@@ -3171,7 +3224,7 @@ class TallyListFreeDrinksCard extends LitElement {
   }
 
   _reset() {
-    this._pending = {};
+    this._fdResetAllCountersToZero();
     this._fdStopCountdown();
     this._fdCountdownLeft = 0;
     this.requestUpdate('_fdCountdownLeft');
@@ -3180,7 +3233,7 @@ class TallyListFreeDrinksCard extends LitElement {
   render() {
     const allUsers = this.config.users || this._autoUsers || [];
     const prices = this.config.prices || this._autoPrices;
-    const pending = this._pending;
+    const counts = this._freeDrinkCounts;
     const comment = this._comment;
     const presets = this.config.comment_presets || [];
     const selectedPreset = presets.find((p) => p.label === this._commentType);
@@ -3232,19 +3285,26 @@ class TallyListFreeDrinksCard extends LitElement {
             ${repeat(
               drinks,
               (d) => d.drink,
-              (d) => html`<tr>
+              (d) => {
+                const count = Number(counts?.[d.drink] || 0);
+                const total = this._getTotalCount();
+                const atPerItemCap = this._perItemCap > 0 && count >= this._perItemCap;
+                const atTotalCap = this._totalCap > 0 && total >= this._totalCap;
+                const disablePlus = atPerItemCap || atTotalCap;
+                return html`<tr>
                   <td>${d.name}</td>
                   ${showPrices
                     ? html`<td>${this._formatPrice(prices[d.drink])} ${this._currency}</td>`
                     : ''}
                   <td class="actions">
                     <div class="tl-counter">
-                      <button class="action-btn btn minus" data-drink="${d.drink}" @pointerdown=${this._dec}>-</button>
-                      <span class="count">${pending[d.drink] || 0}</span>
-                      <button class="action-btn btn plus" data-drink="${d.drink}" @pointerdown=${this._inc}>+</button>
+                      <button class="action-btn btn minus" @pointerdown=${() => this._fdDec(d.drink)}>-</button>
+                      <span class="count">${count}</span>
+                      <button class="action-btn btn plus" ?disabled=${disablePlus} @pointerdown=${() => this._fdInc(d.drink)}>+</button>
                     </div>
                   </td>
-                </tr>`
+                </tr>`;
+              }
             )}
           </tbody>
         </table>
@@ -3274,14 +3334,14 @@ class TallyListFreeDrinksCard extends LitElement {
           <div class="buttons">
             <button
               class="action-btn reset"
-              ?disabled=${this._pendingSum() === 0}
+              ?disabled=${this._getTotalCount() === 0}
               @pointerdown=${this._reset}
             >
               ${fdT(this.hass, this.config.language, 'reset')}
             </button>
             <button
               class="action-btn submit"
-              ?disabled=${!this._validComment() || this._pendingSum() === 0}
+              ?disabled=${!this._validComment() || this._getTotalCount() === 0}
               @pointerdown=${this._submit}
             >
               ${fdT(this.hass, this.config.language, 'submit')}
@@ -3364,6 +3424,15 @@ class TallyListFreeDrinksCard extends LitElement {
       gap: 8px;
     }
     .fd-countdown {
+      font-variant-numeric: tabular-nums;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: var(--chip-background-color, rgba(255,255,255,0.08));
+      color: var(--primary-text-color);
+      line-height: 1.6;
+      font-size: 0.9em;
+    }
+    .fd-rest {
       font-variant-numeric: tabular-nums;
       padding: 2px 8px;
       border-radius: 999px;


### PR DESCRIPTION
## Summary
- add per-item and total caps for free drinks
- show remaining allowance and disable over-cap increments
- document and expose new limits in editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d1ff4530832ebcd31c8a0fabbb5a