### PR TITLE
feat: add free drink limits

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -95,6 +95,8 @@ Optionen:
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
 * **comment_presets** – Vordefinierte Kommentarpräfixe. Jedes Element hat `label` und optional `require_comment`.
 * **free_drinks_timer_seconds** – Auto-Reset-Timer in Sekunden (`0` = aus).
+* **free_drinks_per_item_limit** – Limit je Getränk (`0` = aus).
+* **free_drinks_total_limit** – Gesamtlimit (`0` = aus).
 
 Beispiel:
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Options:
 * **show_prices** – Display drink prices (`true` by default).
 * **comment_presets** – Predefine comment prefixes. Each entry has a `label` and optional `require_comment`.
 * **free_drinks_timer_seconds** – Auto-reset timer in seconds (`0` to disable).
+* **free_drinks_per_item_limit** – Maximum free drinks per item (`0` to disable).
+* **free_drinks_total_limit** – Maximum free drinks overall (`0` to disable).
 
 Example:
 

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -7,6 +7,8 @@ const TL_STRINGS = {
     lock_ms: 'Lock duration (ms)',
     max_width: 'Maximum width (px)',
     free_drinks_timer_seconds: 'Free drinks timer (s)',
+    free_drinks_per_item_limit: 'Free drinks per item limit',
+    free_drinks_total_limit: 'Free drinks total limit',
     show_remove_menu: 'Show remove menu',
     only_self: 'Only show own user even for admins',
     show_step_select: 'Show step selection',
@@ -33,6 +35,8 @@ const TL_STRINGS = {
     lock_ms: 'Sperrzeit (ms)',
     max_width: 'Maximale Breite (px)',
     free_drinks_timer_seconds: 'Freigetränke-Timer (s)',
+    free_drinks_per_item_limit: 'Limit je Getränk (0 = aus)',
+    free_drinks_total_limit: 'Gesamtlimit (0 = aus)',
     show_remove_menu: 'Entfernen-Menü anzeigen',
     only_self: 'Trotz Admin nur eigenen Nutzer anzeigen',
     show_step_select: 'Schrittweiten-Auswahl anzeigen',
@@ -81,6 +85,8 @@ class TallyListCardEditor extends LitElement {
       lock_ms: 400,
       max_width: '500px',
       free_drinks_timer_seconds: 0,
+      free_drinks_per_item_limit: 0,
+      free_drinks_total_limit: 0,
       show_remove: true,
       only_self: false,
       show_step_select: true,
@@ -123,6 +129,22 @@ class TallyListCardEditor extends LitElement {
           type="number"
           .value=${this._config.free_drinks_timer_seconds}
           @input=${this._fdTimerChanged}
+        />
+      </div>
+      <div class="form">
+        <label>${this._t('free_drinks_per_item_limit')}</label>
+        <input
+          type="number"
+          .value=${this._config.free_drinks_per_item_limit}
+          @input=${this._fdPerItemChanged}
+        />
+      </div>
+      <div class="form">
+        <label>${this._t('free_drinks_total_limit')}</label>
+        <input
+          type="number"
+          .value=${this._config.free_drinks_total_limit}
+          @input=${this._fdTotalChanged}
         />
       </div>
       <div class="form">
@@ -298,6 +320,24 @@ class TallyListCardEditor extends LitElement {
     this._config = {
       ...this._config,
       free_drinks_timer_seconds: isNaN(value) ? 0 : value,
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _fdPerItemChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = {
+      ...this._config,
+      free_drinks_per_item_limit: isNaN(value) ? 0 : value,
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _fdTotalChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = {
+      ...this._config,
+      free_drinks_total_limit: isNaN(value) ? 0 : value,
     };
     fireEvent(this, 'config-changed', { config: this._config });
   }


### PR DESCRIPTION
## Summary
- add per-item and total caps for free drinks
- show remaining allowance and disable over-cap increments
- document and expose new limits in editor
- ensure free drink limit options appear in card editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d1ff4530832ebcd31c8a0fabbb5a