### PR TITLE
Show ranking for public devices and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "01.09.2025",
+  "version": "06.09.2025",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
 import { translate, fireEvent } from './tally-list-card.js';
-const CARD_VERSION = '01.09.2025';
+const CARD_VERSION = '06.09.2025';
 
 const TL_STRINGS = {
   en: {


### PR DESCRIPTION
## Summary
- Allow public devices to always display the due ranking for all users
- Bump card version to 06.09.2025
- Cache public-device status to remove initial 5s delay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0af5337c832eae62faea98f04713