### PR TITLE
fix: allow public users without own account to add free drinks

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -3363,8 +3363,9 @@ class TallyListFreeDrinksCard extends LitElement {
   }
 
   get _activeUserId() {
-    if (this._isAdmin) return this.selectedUserId || this.hass?.user?.id || '';
-    return this.hass?.user?.id || '';
+    if (this._isAdmin)
+      return this.selectedUserId || this.sessionUserId || this.hass?.user?.id || '';
+    return this.sessionUserId || this.hass?.user?.id || '';
   }
 
   _gatherUsers() {


### PR DESCRIPTION
## Summary
- ensure free drink bookings use the logged-in session user

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0e72197c832eac4c9627c73ac250