### PR TITLE
Auto-login keypad with separate PIN lock

### DIFF
--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -5,6 +5,7 @@ const CARD_VERSION = '06.09.2025';
 const TL_STRINGS = {
   en: {
     lock_ms: 'Lock duration (ms)',
+    pin_lock_ms: 'PIN lock duration (ms)',
     max_width: 'Maximum width (px)',
     free_drinks_timer_seconds: 'Free drinks timer (s)',
     free_drinks_per_item_limit: 'Free drinks per item limit',
@@ -33,6 +34,7 @@ const TL_STRINGS = {
   },
   de: {
     lock_ms: 'Sperrzeit (ms)',
+    pin_lock_ms: 'PIN-Sperrzeit (ms)',
     max_width: 'Maximale Breite (px)',
     free_drinks_timer_seconds: 'Freigetränke-Timer (s)',
     free_drinks_per_item_limit: 'Limit je Getränk (0 = aus)',
@@ -83,6 +85,7 @@ class TallyListCardEditor extends LitElement {
     };
     this._config = {
       lock_ms: 400,
+      pin_lock_ms: 5000,
       max_width: '500px',
       free_drinks_timer_seconds: 0,
       free_drinks_per_item_limit: 0,
@@ -113,6 +116,14 @@ class TallyListCardEditor extends LitElement {
           type="number"
           .value=${this._config.lock_ms}
           @input=${this._lockChanged}
+        />
+      </div>
+      <div class="form">
+        <label>${this._t('pin_lock_ms')}</label>
+        <input
+          type="number"
+          .value=${this._config.pin_lock_ms}
+          @input=${this._pinLockChanged}
         />
       </div>
       <div class="form">
@@ -226,6 +237,12 @@ class TallyListCardEditor extends LitElement {
         <div class="version">${this._t('version')}: ${CARD_VERSION}</div>
       </details>
     `;
+  }
+
+  _pinLockChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = { ...this._config, pin_lock_ms: isNaN(value) ? 5000 : value };
+    fireEvent(this, 'config-changed', { config: this._config });
   }
 
   _lockChanged(ev) {


### PR DESCRIPTION
## Summary
- add `pin_lock_ms` option to configure keypad lock duration after wrong PIN (default 5s)
- keep existing `lock_ms` for button press delay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc101707c4832eb6c5c87818fed7a7