### PR TITLE
Clear PIN input instead of removing last digit

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -172,7 +172,7 @@ function _psAddDigit(card, d) {
 
 function _psBackspace(card) {
   if (card.loginPending || card.pinLocked) return;
-  card.pinBuffer = card.pinBuffer.slice(0, -1);
+  card.pinBuffer = '';
   _psNotify();
 }
 
@@ -267,7 +267,7 @@ function renderCoverLogin(card) {
           }
         }
       );
-  const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, '⌫', 0];
+  const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, '⟲', 0];
   const pinMask = Array.from({ length: 4 }, (_, i) =>
     html`<span class="pin-dot ${card.pinBuffer.length > i ? 'filled' : ''}"></span>`
   );
@@ -284,10 +284,10 @@ function renderCoverLogin(card) {
     </div>
     <div class="keypad">
       ${digits.map((d) =>
-        d === '⌫'
+        d === '⟲'
           ? html`<button class="key action-btn del" @click=${() => _psBackspace(card)} ?disabled=${
               card.loginPending || card.pinLocked
-            }>⌫</button>`
+            }>⟲</button>`
           : html`<button class="key action-btn" @click=${() => _psAddDigit(card, d)} ?disabled=${
               card.loginPending || card.pinLocked
             }>${d}</button>`


### PR DESCRIPTION
## Summary
- Replace backspace logic with full PIN reset when pressing delete
- Display a circular arrow symbol (⟲) for the reset button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc18303f30832ebea82ce732589f7a