### PR TITLE
Fix pin login button focus outline

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -285,12 +285,18 @@ function renderCoverLogin(card) {
     <div class="keypad">
       ${digits.map((d) =>
         d === '⟲'
-          ? html`<button class="key action-btn del" @click=${() => _psBackspace(card)} ?disabled=${
-              card.loginPending || card.pinLocked
-            }>⟲</button>`
-          : html`<button class="key action-btn" @click=${() => _psAddDigit(card, d)} ?disabled=${
-              card.loginPending || card.pinLocked
-            }>${d}</button>`
+          ? html`<button class="key action-btn del" @pointerdown=${(ev) => {
+              ev.preventDefault();
+              ev.stopPropagation();
+              ev.currentTarget.blur();
+              _psBackspace(card);
+            }} ?disabled=${card.loginPending || card.pinLocked}>⟲</button>`
+          : html`<button class="key action-btn" @pointerdown=${(ev) => {
+              ev.preventDefault();
+              ev.stopPropagation();
+              ev.currentTarget.blur();
+              _psAddDigit(card, d);
+            }} ?disabled=${card.loginPending || card.pinLocked}>${d}</button>`
       )}
     </div></div></ha-card>`;
 }


### PR DESCRIPTION
## Summary
- avoid focus outline on PIN keypad buttons
- blur PIN keypad buttons after press to prevent lingering outline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1bd22bb8832e88cd57699077fc77