### PR TITLE
feat: make session timeout configurable

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -55,6 +55,7 @@ data:
 Folgende Optionen stehen im UI zur Verfügung:
 
 * **Sperrzeit (ms)** – Wie lange die Buttons nach dem Drücken deaktiviert bleiben. Standard `400`.
+* **Session-Timeout (s)** – Zeit bis zum automatischen Logout nach dem Login. Standard `30`.
 * **Maximale Breite (px)** – Begrenzung der Kartenbreite. Standard `500`.
 * **Entfernen-Menü anzeigen** – Ein-/Ausblenden des Menüs zum Entfernen.
 * **Schrittweiten-Auswahl anzeigen** – Schaltflächen zur Auswahl der Schrittweite (1, 3, 5, 10) anzeigen.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The **Remove drink** button subtracts drinks with a `tally_list.remove_drink` ca
 The card offers the following options in the UI:
 
 * **Lock time (ms)** – Duration the buttons stay disabled after pressing them. Default `400`.
+* **Session timeout (s)** – Time after login before automatic logout. Default `30`.
 * **Maximum width (px)** – Limit card width. Default `500`.
 * **Show remove menu** – Enable/disable the remove-drink dropdown.
 * **Show step selection** – Show buttons to select the step size (1, 3, 5, 10).

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -6,6 +6,7 @@ const TL_STRINGS = {
   en: {
     lock_ms: 'Lock duration (ms)',
     pin_lock_ms: 'PIN lock duration (ms)',
+    session_timeout_seconds: 'Session timeout (s)',
     max_width: 'Maximum width (px)',
     free_drinks_timer_seconds: 'Free drinks timer (s)',
     free_drinks_per_item_limit: 'Free drinks per item limit',
@@ -35,6 +36,7 @@ const TL_STRINGS = {
   de: {
     lock_ms: 'Sperrzeit (ms)',
     pin_lock_ms: 'PIN-Sperrzeit (ms)',
+    session_timeout_seconds: 'Session-Timeout (s)',
     max_width: 'Maximale Breite (px)',
     free_drinks_timer_seconds: 'Freigetränke-Timer (s)',
     free_drinks_per_item_limit: 'Limit je Getränk (0 = aus)',
@@ -86,6 +88,7 @@ class TallyListCardEditor extends LitElement {
     this._config = {
       lock_ms: 400,
       pin_lock_ms: 5000,
+      session_timeout_seconds: 30,
       max_width: '500px',
       free_drinks_timer_seconds: 0,
       free_drinks_per_item_limit: 0,
@@ -124,6 +127,14 @@ class TallyListCardEditor extends LitElement {
           type="number"
           .value=${this._config.pin_lock_ms}
           @input=${this._pinLockChanged}
+        />
+      </div>
+      <div class="form">
+        <label>${this._t('session_timeout_seconds')}</label>
+        <input
+          type="number"
+          .value=${this._config.session_timeout_seconds}
+          @input=${this._sessionTimeoutChanged}
         />
       </div>
       <div class="form">
@@ -248,6 +259,15 @@ class TallyListCardEditor extends LitElement {
   _lockChanged(ev) {
     const value = Number(ev.target.value);
     this._config = { ...this._config, lock_ms: isNaN(value) ? 400 : value };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _sessionTimeoutChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = {
+      ...this._config,
+      session_timeout_seconds: isNaN(value) ? 30 : value,
+    };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -83,9 +83,10 @@ function _psUnsubscribe(card) {
   PUBLIC_SESSION.subs.delete(card);
 }
 
-function _psTouch() {
+function _psTouch(card) {
   if (PUBLIC_SESSION.sessionReady && PUBLIC_SESSION.isPublic) {
-    PUBLIC_SESSION.sessionExpiresAt = Date.now() + 30000;
+    const timeout = Number(card?.config?.session_timeout_seconds ?? 30);
+    PUBLIC_SESSION.sessionExpiresAt = Date.now() + timeout * 1000;
   }
 }
 
@@ -97,8 +98,9 @@ function _psStopCountdown() {
 }
 
 function _psStartCountdown(card) {
-  PUBLIC_SESSION.sessionExpiresAt = Date.now() + 30000;
-  PUBLIC_SESSION.countdownSec = 30;
+  const timeout = Number(card.config.session_timeout_seconds ?? 30);
+  PUBLIC_SESSION.sessionExpiresAt = Date.now() + timeout * 1000;
+  PUBLIC_SESSION.countdownSec = timeout;
   if (!PUBLIC_SESSION.countdownTimer) {
     PUBLIC_SESSION.countdownTimer = setInterval(() => {
       PUBLIC_SESSION.countdownSec = Math.max(
@@ -794,6 +796,7 @@ class TallyListCard extends LitElement {
     this.config = {
       lock_ms: 400,
       pin_lock_ms: 5000,
+      session_timeout_seconds: 30,
       max_width: '500px',
       show_remove: true,
       only_self: false,
@@ -1091,7 +1094,7 @@ class TallyListCard extends LitElement {
   _selectRemoveDrink(ev) {
     this.selectedRemoveDrink = ev.target.value;
     this.requestUpdate();
-    _psTouch();
+    _psTouch(this);
   }
 
   _onSelectCount(ev) {
@@ -1100,7 +1103,7 @@ class TallyListCard extends LitElement {
     const count = Number(ev.currentTarget.dataset.count);
     this.selectedCount = count;
     this.requestUpdate('selectedCount');
-    _psTouch();
+    _psTouch(this);
   }
 
   _onAddDrink(ev) {
@@ -1118,7 +1121,7 @@ class TallyListCard extends LitElement {
   }
 
   _addDrink(drink) {
-    _psTouch();
+    _psTouch(this);
     if (this._disabled) {
       return;
     }
@@ -1168,7 +1171,7 @@ class TallyListCard extends LitElement {
   }
 
   _removeDrink(drink) {
-    _psTouch();
+    _psTouch(this);
     if (this._disabled || !drink) {
       return;
     }
@@ -3444,6 +3447,9 @@ class TallyListFreeDrinksCard extends LitElement {
       tabs,
       grid,
     };
+    this.config.session_timeout_seconds = Number(
+      config?.session_timeout_seconds ?? 30
+    );
     this.config.free_drinks_timer_seconds = Number(
       config?.free_drinks_timer_seconds ?? 0
     );
@@ -3633,7 +3639,7 @@ class TallyListFreeDrinksCard extends LitElement {
   }
 
   _fdInc(drinkId) {
-    _psTouch();
+    _psTouch(this);
     const perCap = this._perItemCap;
     const totalCap = this._totalCap;
 
@@ -3649,7 +3655,7 @@ class TallyListFreeDrinksCard extends LitElement {
   }
 
   _fdDec(drinkId) {
-    _psTouch();
+    _psTouch(this);
     const current = Number(this._freeDrinkCounts?.[drinkId] || 0);
     const next = Math.max(0, current - 1);
     if (next === current) return;
@@ -3733,12 +3739,12 @@ class TallyListFreeDrinksCard extends LitElement {
 
   _onComment(ev) {
     this._comment = ev.target.value;
-    _psTouch();
+    _psTouch(this);
   }
 
   _onPreset(ev) {
     this._commentType = ev.target.value;
-    _psTouch();
+    _psTouch(this);
   }
 
   _validComment() {
@@ -3783,7 +3789,7 @@ class TallyListFreeDrinksCard extends LitElement {
   }
 
   async _submit() {
-    _psTouch();
+    _psTouch(this);
     if (!this._validComment() || this._getTotalCount() === 0) return;
     const extra = this._comment.trim();
     const comment = this._commentType
@@ -3840,7 +3846,7 @@ class TallyListFreeDrinksCard extends LitElement {
   }
 
   _reset() {
-    _psTouch();
+    _psTouch(this);
     this._fdResetAllCountersToZero();
     this._fdStopCountdown();
     this._fdCountdownLeft = 0;


### PR DESCRIPTION
## Summary
- add `session_timeout_seconds` option for public sessions
- support new option in card editor and documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc1eb2c4a8832eb82da598e21ea0be