### PR TITLE
feat: make session timeout configurable

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -55,6 +55,7 @@ data:
 Folgende Optionen stehen im UI zur Verfügung:
 
 * **Sperrzeit (ms)** – Wie lange die Buttons nach dem Drücken deaktiviert bleiben. Standard `400`.
+* **Session-Timeout (s)** – Zeit bis zum automatischen Logout nach dem Login. Standard `30`.
 * **Maximale Breite (px)** – Begrenzung der Kartenbreite. Standard `500`.
 * **Entfernen-Menü anzeigen** – Ein-/Ausblenden des Menüs zum Entfernen.
 * **Schrittweiten-Auswahl anzeigen** – Schaltflächen zur Auswahl der Schrittweite (1, 3, 5, 10) anzeigen.
@@ -94,6 +95,7 @@ Optionen:
 
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
 * **comment_presets** – Vordefinierte Kommentarpräfixe. Jedes Element hat `label` und optional `require_comment`.
+* **session_timeout_seconds** – Zeit bis zum automatischen Logout nach dem Login (`30` standardmäßig).
 * **free_drinks_timer_seconds** – Auto-Reset-Timer in Sekunden (`0` = aus).
 * **free_drinks_per_item_limit** – Limit je Getränk (`0` = aus).
 * **free_drinks_total_limit** – Gesamtlimit (`0` = aus).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The **Remove drink** button subtracts drinks with a `tally_list.remove_drink` ca
 The card offers the following options in the UI:
 
 * **Lock time (ms)** – Duration the buttons stay disabled after pressing them. Default `400`.
+* **Session timeout (s)** – Time after login before automatic logout. Default `30`.
 * **Maximum width (px)** – Limit card width. Default `500`.
 * **Show remove menu** – Enable/disable the remove-drink dropdown.
 * **Show step selection** – Show buttons to select the step size (1, 3, 5, 10).
@@ -95,6 +96,7 @@ Options:
 
 * **show_prices** – Display drink prices (`true` by default).
 * **comment_presets** – Predefine comment prefixes. Each entry has a `label` and optional `require_comment`.
+* **session_timeout_seconds** – Time after login before automatic logout (`30` by default).
 * **free_drinks_timer_seconds** – Auto-reset timer in seconds (`0` to disable).
 * **free_drinks_per_item_limit** – Maximum free drinks per item (`0` to disable).
 * **free_drinks_total_limit** – Maximum free drinks overall (`0` to disable).

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -6,6 +6,7 @@ const TL_STRINGS = {
   en: {
     lock_ms: 'Lock duration (ms)',
     pin_lock_ms: 'PIN lock duration (ms)',
+    session_timeout_seconds: 'Session timeout (s)',
     max_width: 'Maximum width (px)',
     free_drinks_timer_seconds: 'Free drinks timer (s)',
     free_drinks_per_item_limit: 'Free drinks per item limit',
@@ -35,6 +36,7 @@ const TL_STRINGS = {
   de: {
     lock_ms: 'Sperrzeit (ms)',
     pin_lock_ms: 'PIN-Sperrzeit (ms)',
+    session_timeout_seconds: 'Session-Timeout (s)',
     max_width: 'Maximale Breite (px)',
     free_drinks_timer_seconds: 'Freigetränke-Timer (s)',
     free_drinks_per_item_limit: 'Limit je Getränk (0 = aus)',
@@ -86,6 +88,7 @@ class TallyListCardEditor extends LitElement {
     this._config = {
       lock_ms: 400,
       pin_lock_ms: 5000,
+      session_timeout_seconds: 30,
       max_width: '500px',
       free_drinks_timer_seconds: 0,
       free_drinks_per_item_limit: 0,
@@ -124,6 +127,14 @@ class TallyListCardEditor extends LitElement {
           type="number"
           .value=${this._config.pin_lock_ms}
           @input=${this._pinLockChanged}
+        />
+      </div>
+      <div class="form">
+        <label>${this._t('session_timeout_seconds')}</label>
+        <input
+          type="number"
+          .value=${this._config.session_timeout_seconds}
+          @input=${this._sessionTimeoutChanged}
         />
       </div>
       <div class="form">
@@ -248,6 +259,15 @@ class TallyListCardEditor extends LitElement {
   _lockChanged(ev) {
     const value = Number(ev.target.value);
     this._config = { ...this._config, lock_ms: isNaN(value) ? 400 : value };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _sessionTimeoutChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = {
+      ...this._config,
+      session_timeout_seconds: isNaN(value) ? 30 : value,
+    };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 


### PR DESCRIPTION
## Summary
- add `session_timeout_seconds` option for public sessions
- show session timeout in both tally list and free-drinks card editors
- document free drinks card session timeout option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1eb2c4a8832eb82da598e21ea0be