### PR TITLE
feat: add PIN lock duration to free drinks card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -96,6 +96,7 @@ Optionen:
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
 * **comment_presets** – Vordefinierte Kommentarpräfixe. Jedes Element hat `label` und optional `require_comment`.
 * **session_timeout_seconds** – Zeit bis zum automatischen Logout nach dem Login (`30` standardmäßig).
+* **pin_lock_ms** – PIN-Sperrzeit in Millisekunden (`5000` standardmäßig).
 * **free_drinks_timer_seconds** – Auto-Reset-Timer in Sekunden (`0` = aus).
 * **free_drinks_per_item_limit** – Limit je Getränk (`0` = aus).
 * **free_drinks_total_limit** – Gesamtlimit (`0` = aus).

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Options:
 * **show_prices** – Display drink prices (`true` by default).
 * **comment_presets** – Predefine comment prefixes. Each entry has a `label` and optional `require_comment`.
 * **session_timeout_seconds** – Time after login before automatic logout (`30` by default).
+* **pin_lock_ms** – PIN lock duration in milliseconds (`5000` by default).
 * **free_drinks_timer_seconds** – Auto-reset timer in seconds (`0` to disable).
 * **free_drinks_per_item_limit** – Maximum free drinks per item (`0` to disable).
 * **free_drinks_total_limit** – Maximum free drinks overall (`0` to disable).

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -3041,6 +3041,7 @@ class TallyListFreeDrinksCardEditor extends LitElement {
       free_drinks_per_item_limit: 0,
       free_drinks_total_limit: 0,
       session_timeout_seconds: 30,
+      pin_lock_ms: 5000,
       language: 'auto',
       user_selector: 'list',
       ...(config || {}),
@@ -3055,6 +3056,7 @@ class TallyListFreeDrinksCardEditor extends LitElement {
     const idPrices = this._fid('prices');
     const idPresets = this._fid('presets');
     const idSessionTimeout = this._fid('session-timeout');
+    const idPinLock = this._fid('pin-lock-ms');
     const idLanguage = this._fid('language');
     const idUserSelector = this._fid('user-selector');
     const idTabMode = this._fid('tab-mode');
@@ -3095,6 +3097,15 @@ class TallyListFreeDrinksCardEditor extends LitElement {
           type="number"
           .value=${this._config.session_timeout_seconds}
           @input=${this._sessionTimeoutChanged}
+        />
+      </div>
+      <div class="form">
+        <label for="${idPinLock}">${t(this.hass, this._config.language, 'pin_lock_ms')}</label>
+        <input
+          id="${idPinLock}"
+          type="number"
+          .value=${this._config.pin_lock_ms}
+          @input=${this._pinLockChanged}
         />
       </div>
       <div class="form">
@@ -3211,6 +3222,15 @@ class TallyListFreeDrinksCardEditor extends LitElement {
     this._config = {
       ...this._config,
       session_timeout_seconds: isNaN(value) ? 30 : value,
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _pinLockChanged(ev) {
+    const value = Number(ev.target.value);
+    this._config = {
+      ...this._config,
+      pin_lock_ms: isNaN(value) ? 5000 : value,
     };
     fireEvent(this, 'config-changed', { config: this._config });
   }
@@ -3483,6 +3503,7 @@ class TallyListFreeDrinksCard extends LitElement {
     const grid = { columns: 0, ...(config?.grid || {}) };
     this.config = {
       show_prices: true,
+      pin_lock_ms: 5000,
       language: 'auto',
       user_selector: 'list',
       ...(config || {}),
@@ -3502,6 +3523,7 @@ class TallyListFreeDrinksCard extends LitElement {
     this.config.free_drinks_total_limit = Number(
       config?.free_drinks_total_limit ?? 0
     );
+    this.config.pin_lock_ms = Number(config?.pin_lock_ms ?? 5000);
     if (!this._commentType && this.config.comment_presets?.length) {
       this._commentType = this.config.comment_presets[0].label;
     }


### PR DESCRIPTION
## Summary
- add configurable PIN lock duration to the free drinks card editor
- parse `pin_lock_ms` in free drinks card config
- document `pin_lock_ms` option for the free drinks card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc238afab4832eb7f9aa20621e7015