### PR TITLE
Remove unused step selection option from ranking card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -81,7 +81,6 @@ Optionen:
 * **max_entries** – Anzahl angezeigter Nutzer begrenzen (`0` = unbegrenzt).
 * **hide_free** – Nutzer ohne offenen Betrag ausblenden.
 * **show_copy** – Schaltfläche **Tabelle kopieren** anzeigen.
-* **show_step_select** – Auswahl der Schrittweiten anzeigen.
 
 ## Freigetränke-Karte
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Options:
 * **max_entries** – Limit how many users are shown (`0` = no limit).
 * **hide_free** – Hide users who owe nothing.
 * **show_copy** – Show the "Tabelle kopieren" button.
-* **show_step_select** – Show buttons to select the step size.
 
 ## Free Drinks Card
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -2466,7 +2466,6 @@ class TallyDueRankingCard extends LitElement {
       max_entries: 0,
       hide_free: false,
       show_copy: true,
-      show_step_select: true,
     };
   }
   _gatherUsers() {
@@ -2756,7 +2755,6 @@ class TallyDueRankingCardEditor extends LitElement {
       max_entries: 0,
       hide_free: false,
       show_copy: true,
-      show_step_select: true,
       language: 'auto',
       ...config,
     };
@@ -2776,7 +2774,6 @@ class TallyDueRankingCardEditor extends LitElement {
     const idShowCopy = this._fid('show-copy');
     const idShowTotal = this._fid('show-total');
     const idHideFree = this._fid('hide-free');
-    const idShowStepSelect = this._fid('show-step-select');
     const idShowResetEveryone = this._fid('show-reset-everyone');
     const idLanguage = this._fid('language');
     return html`
@@ -2815,10 +2812,6 @@ class TallyDueRankingCardEditor extends LitElement {
       <div class="form">
         <input id="${idHideFree}" name="hide_free" type="checkbox" .checked=${this._config.hide_free} @change=${this._hideChanged} />
         <label for="${idHideFree}">${this._t('hide_free')}</label>
-      </div>
-      <div class="form">
-        <input id="${idShowStepSelect}" name="show_step_select" type="checkbox" .checked=${this._config.show_step_select !== false} @change=${this._stepSelectChanged} />
-        <label for="${idShowStepSelect}">${this._t('show_step_select')}</label>
       </div>
       <details class="debug">
         <summary>${this._t('debug')}</summary>
@@ -2880,11 +2873,6 @@ class TallyDueRankingCardEditor extends LitElement {
 
   _hideChanged(ev) {
     this._config = { ...this._config, hide_free: ev.target.checked };
-    fireEvent(this, 'config-changed', { config: this._config });
-  }
-
-  _stepSelectChanged(ev) {
-    this._config = { ...this._config, show_step_select: ev.target.checked };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 


### PR DESCRIPTION
## Summary
- drop unused show_step_select option from ranking card config and editor
- update documentation to match removed option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc25645d00832eb9c74fdf02f59c6c