### PR TITLE
Require user selection before PIN entry

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -84,7 +84,7 @@ Optionen:
 
 ## Freigetränke-Karte
 
-Bucht Freigetränke mit Pflichtkommentar. Zähler werden lokal gepuffert, bis sie abgeschickt werden. Mit dem Reset-Button lassen sich alle Zähler zurücksetzen.
+Bucht Freigetränke mit Pflichtkommentar. Zähler werden lokal gepuffert, bis sie abgeschickt werden. Mit dem Reset-Button lassen sich alle Zähler zurücksetzen. Vor der PIN-Eingabe muss ein Nutzer gewählt werden.
 
 ```yaml
 type: custom:tally-list-free-drinks-card

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Options:
 
 ## Free Drinks Card
 
-Book free drinks with a mandatory comment. Counts are kept locally until submitted. Use the reset button to clear all counts.
+Book free drinks with a mandatory comment. Counts are kept locally until submitted. Use the reset button to clear all counts. A user must be selected before entering the PIN.
 
 ```yaml
 type: custom:tally-list-free-drinks-card

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -164,6 +164,7 @@ async function wsLogin(hass, userLabel, pinStr) {
 
 function _psAddDigit(card, d) {
   if (card.loginPending || card.pinLocked) return;
+  if (!card.selectedUser) return;
   if (card.pinBuffer.length >= 4) return;
   card.pinBuffer += String(d);
   _psNotify();
@@ -174,6 +175,7 @@ function _psAddDigit(card, d) {
 
 function _psBackspace(card) {
   if (card.loginPending || card.pinLocked) return;
+  if (!card.selectedUser) return;
   card.pinBuffer = '';
   _psNotify();
 }
@@ -292,13 +294,13 @@ function renderCoverLogin(card) {
               ev.stopPropagation();
               ev.currentTarget.blur();
               _psBackspace(card);
-            }} ?disabled=${card.loginPending || card.pinLocked}>⟲</button>`
+            }} ?disabled=${card.loginPending || card.pinLocked || !card.selectedUser}>⟲</button>`
           : html`<button class="key action-btn" @pointerdown=${(ev) => {
               ev.preventDefault();
               ev.stopPropagation();
               ev.currentTarget.blur();
               _psAddDigit(card, d);
-            }} ?disabled=${card.loginPending || card.pinLocked}>${d}</button>`
+            }} ?disabled=${card.loginPending || card.pinLocked || !card.selectedUser}>${d}</button>`
       )}
     </div></div></ha-card>`;
 }


### PR DESCRIPTION
## Summary
- Disallow PIN entry until a user is chosen and disable keypad when no user is selected
- Document that a user must be selected before entering the PIN

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc27e215e4832e8ac27e5b0ba39055