### PR TITLE
Clear PIN when switching users

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -3633,6 +3633,8 @@ class TallyListFreeDrinksCard extends LitElement {
     if (id && this.selectedUserId !== id) {
       this.selectedUserId = id;
       this.requestUpdate('selectedUserId');
+      this.pinBuffer = '';
+      _psNotify();
     }
   }
 


### PR DESCRIPTION
## Summary
- Reset PIN input whenever a different user is selected to avoid carrying over previous digits.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc28e02ecc832e8271e57525148132