### PR TITLE
fix: sync pin lock timer across cards

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -3422,6 +3422,27 @@ class TallyListFreeDrinksCard extends LitElement {
     PUBLIC_SESSION.pinLocked = v;
   }
 
+  get pinLockUntil() {
+    return PUBLIC_SESSION.pinLockUntil;
+  }
+  set pinLockUntil(v) {
+    PUBLIC_SESSION.pinLockUntil = v;
+  }
+
+  get pinLockRemainingMs() {
+    return PUBLIC_SESSION.pinLockRemainingMs;
+  }
+  set pinLockRemainingMs(v) {
+    PUBLIC_SESSION.pinLockRemainingMs = v;
+  }
+
+  get pinLockTimer() {
+    return PUBLIC_SESSION.pinLockTimer;
+  }
+  set pinLockTimer(v) {
+    PUBLIC_SESSION.pinLockTimer = v;
+  }
+
   get countdownSec() {
     return PUBLIC_SESSION.countdownSec;
   }


### PR DESCRIPTION
## Summary
- ensure free drinks card shares pin lock timer state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2bc5ae08832e91f47356e73c548e