### PR TITLE
feat: add PIN management card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -111,3 +111,15 @@ comment_presets:
     require_comment: false
 ```
 
+
+## PIN-Karte
+
+Nutzer können ihre eigene 4-stellige PIN setzen oder zurücksetzen. Administratoren können für jeden Nutzer die PIN festlegen. Die Karte kann über den Lovelace-Karteneditor hinzugefügt werden.
+Beim Öffnen der Karte erscheint ein Hinweis, keine wichtige PIN (z. B. die der Bankkarte) zu verwenden, da nicht garantiert werden kann, dass sie nicht entwendet wird.
+
+```yaml
+type: custom:tally-set-pin-card
+```
+
+Die Karte verwendet die gleiche Benutzerliste wie die Hauptkarte und benötigt normalerweise keine zusätzliche Konfiguration.
+

--- a/README.md
+++ b/README.md
@@ -112,3 +112,15 @@ comment_presets:
     require_comment: false
 ```
 
+
+## PIN Set Card
+
+Allow users to set or reset their 4-digit PIN. Administrators can select any user and update the PIN for them. The card is available in the Lovelace card picker.
+When opened, a warning reminds users not to use important PINs such as their bank card PIN, since its security cannot be guaranteed.
+
+```yaml
+type: custom:tally-set-pin-card
+```
+
+The card uses the same user list as the main Tally List card and normally requires no additional configuration.
+


### PR DESCRIPTION
## Summary
- add PIN management card for users and admins
- warn users not to use sensitive PINs before entry
- document new card and warning in English and German READMEs
- embed PIN card into main bundle and expose editor for Lovelace UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc31c66b28832ebc926b9badb01216