### PR TITLE
feat: add PIN management card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -111,3 +111,24 @@ comment_presets:
     require_comment: false
 ```
 
+
+## PIN-Karte
+
+Nutzer können ihre eigene 4-stellige PIN setzen oder zurücksetzen. Administratoren können für jeden Nutzer die PIN festlegen. Die Karte kann über den Lovelace-Karteneditor hinzugefügt werden.
+Beim Öffnen der Karte erscheint ein Hinweis, keine wichtige PIN (z. B. die der Bankkarte) zu verwenden, da nicht garantiert werden kann, dass sie nicht entwendet wird.
+
+```yaml
+type: custom:tally-set-pin-card
+```
+
+Die Karte verwendet die gleiche Benutzerliste wie die Hauptkarte und benötigt normalerweise keine zusätzliche Konfiguration.
+
+Zum Speichern der neuen PIN wird der Service `tally_list.set_pin` aufgerufen, z. B.:
+
+```yaml
+action: tally_list.set_pin
+data:
+  user: Erika Mustermann
+  pin: "1234"
+```
+

--- a/README.md
+++ b/README.md
@@ -112,3 +112,24 @@ comment_presets:
     require_comment: false
 ```
 
+
+## PIN Set Card
+
+Allow users to set or reset their 4-digit PIN. Administrators can select any user and update the PIN for them. The card is available in the Lovelace card picker.
+When opened, a warning reminds users not to use important PINs such as their bank card PIN, since its security cannot be guaranteed.
+
+```yaml
+type: custom:tally-set-pin-card
+```
+
+The card uses the same user list as the main Tally List card and normally requires no additional configuration.
+
+It calls the `tally_list.set_pin` service to store the new code, e.g.:
+
+```yaml
+action: tally_list.set_pin
+data:
+  user: Erika Mustermann
+  pin: "1234"
+```
+

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -4272,3 +4272,387 @@ class TallyListFreeDrinksCard extends LitElement {
 
 customElements.define('tally-list-free-drinks-card', TallyListFreeDrinksCard);
 
+// ----- Set PIN Card Editor -----
+const PIN_EDITOR_STRINGS = {
+  en: { no_options: 'No options available' },
+  de: { no_options: 'Keine Optionen verfügbar' },
+};
+
+class TallySetPinCardEditor extends LitElement {
+  static properties = {
+    _config: {},
+  };
+
+  setConfig(config) {
+    this._config = { ...config };
+  }
+
+  render() {
+    return html`<div class="form">${translate(
+      this.hass,
+      this._config?.language,
+      PIN_EDITOR_STRINGS,
+      'no_options'
+    )}</div>`;
+  }
+}
+
+customElements.define('tally-set-pin-card-editor', TallySetPinCardEditor);
+
+// ----- Set PIN Card -----
+const PIN_STRINGS = {
+  en: {
+    card_name: 'Set PIN',
+    card_desc: 'Allow users to set their 4-digit PIN',
+    select_user: 'User',
+    new_pin: 'New PIN',
+    confirm_pin: 'Confirm PIN',
+    set_pin: 'Set PIN',
+    success: 'PIN updated',
+    mismatch: 'PINs do not match',
+    invalid: 'Enter 4 digits',
+    error: 'Failed to set PIN',
+    warning:
+      'Do not use an important PIN (e.g., your bank card PIN); its security cannot be guaranteed.',
+    ok: 'Got it',
+  },
+  de: {
+    card_name: 'PIN setzen',
+    card_desc: 'Ermöglicht Benutzern, ihre 4-stellige PIN zu setzen',
+    select_user: 'Benutzer',
+    new_pin: 'Neue PIN',
+    confirm_pin: 'PIN bestätigen',
+    set_pin: 'PIN setzen',
+    success: 'PIN aktualisiert',
+    mismatch: 'PINs stimmen nicht überein',
+    invalid: '4 Ziffern eingeben',
+    error: 'PIN konnte nicht gesetzt werden',
+    warning:
+      'Bitte keine wichtige PIN (z. B. die der Bankkarte) verwenden, da nicht gewährleistet werden kann, dass sie nicht gestohlen wird.',
+    ok: 'Verstanden',
+  },
+};
+
+window.customCards = window.customCards || [];
+const pinNavLang = detectLang();
+window.customCards.push({
+  type: 'tally-set-pin-card',
+  name: PIN_STRINGS[pinNavLang].card_name,
+  preview: true,
+  description: PIN_STRINGS[pinNavLang].card_desc,
+});
+
+class TallySetPinCard extends LitElement {
+  static properties = {
+    hass: {},
+    config: {},
+    selectedUserId: { type: String },
+    _pin1: { state: true },
+    _pin2: { state: true },
+    _status: { state: true },
+    _showWarn: { state: true },
+    _autoUsers: { state: true },
+    _buffer: { state: true },
+    _stage: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.selectedUserId = '';
+    this._pin1 = '';
+    this._pin2 = '';
+    this._status = '';
+    this._showWarn = true;
+    this._autoUsers = [];
+    this._buffer = '';
+    this._stage = 1; // 1: enter new PIN, 2: confirm PIN
+  }
+
+  setConfig(config) {
+    this.config = config || {};
+  }
+
+  _t(key) {
+    return translate(this.hass, this.config.language, PIN_STRINGS, key);
+  }
+
+  get _users() {
+    return this.config.users || this._autoUsers || [];
+  }
+
+  get _isAdmin() {
+    return this.hass?.user?.is_admin;
+  }
+
+  _handleSelect(ev) {
+    this.selectedUserId = ev.target.value;
+  }
+
+  updated(changedProps) {
+    if (changedProps.has('hass') && !this.config.users) {
+      this._autoUsers = this._gatherUsers();
+    }
+  }
+
+  _gatherUsers() {
+    const users = [];
+    const states = this.hass?.states || {};
+    for (const [entity, state] of Object.entries(states)) {
+      const match = entity.match(/^sensor\.([a-z0-9_]+)_amount_due$/);
+      if (match) {
+        const slug = match[1];
+        if (slug === 'free_drinks') continue;
+        const sensorName = (state.attributes.friendly_name || '')
+          .replace(' Amount Due', '')
+          .replace(' Offener Betrag', '');
+        const person = states[`person.${slug}`];
+        const user_id = person?.attributes?.user_id || null;
+        const name = person?.attributes?.friendly_name || sensorName || slug;
+        users.push({ name, slug, user_id });
+      }
+    }
+    return users;
+  }
+
+  _addDigit(d) {
+    if (this._buffer.length >= 4) return;
+    this._buffer += String(d);
+    if (this._buffer.length === 4) {
+      if (this._stage === 1) {
+        this._pin1 = this._buffer;
+        this._buffer = '';
+        this._stage = 2;
+      } else {
+        this._pin2 = this._buffer;
+        this._buffer = '';
+        this._submit();
+      }
+    }
+  }
+
+  _backspace() {
+    if (this._buffer) {
+      this._buffer = '';
+    } else if (this._stage === 2) {
+      this._stage = 1;
+      this._pin1 = '';
+      this._pin2 = '';
+    }
+  }
+
+  async _submit() {
+    if (this._pin1 !== this._pin2 || this._pin1.length !== 4) {
+      this._status = this._pin1 !== this._pin2 ? 'mismatch' : 'invalid';
+      return;
+    }
+    const users = this._users;
+    let label;
+    if (this._isAdmin) {
+      const u = users.find(
+        (u) =>
+          u.user_id === this.selectedUserId ||
+          u.name === this.selectedUserId ||
+          u.slug === this.selectedUserId
+      );
+      label = u?.name || u?.slug;
+    } else {
+      label = this.hass?.user?.name;
+    }
+    if (!label) {
+      this._status = 'invalid';
+      return;
+    }
+    try {
+      await this.hass.callService('tally_list', 'set_pin', {
+        user: String(label),
+        pin: String(this._pin1),
+      });
+      this._status = 'success';
+      this._pin1 = '';
+      this._pin2 = '';
+      this._stage = 1;
+    } catch (e) {
+      const code = e?.error?.code || e?.code;
+      this._status = code || 'error';
+      this._stage = 1;
+    }
+  }
+
+  render() {
+    const users = this._users;
+    const isAdmin = this._isAdmin;
+    const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, '⟲', 0];
+    const pinMask = Array.from({ length: 4 }, (_, i) =>
+      html`<span class="pin-dot ${this._buffer.length > i ? 'filled' : ''}"></span>`
+    );
+    return html`
+      <ha-card>
+        ${this._showWarn
+          ? html`<div class="warn-overlay">
+              <div class="warn-box">
+                <p>${this._t('warning')}</p>
+                <button class="action-btn" @click=${() => (this._showWarn = false)}>
+                  ${this._t('ok')}
+                </button>
+              </div>
+            </div>`
+          : ''}
+        <div class="content">
+          ${isAdmin
+            ? html`<label class="form">
+                <span>${this._t('select_user')}</span>
+                <select @change=${this._handleSelect} .value=${this.selectedUserId}>
+                  <option value=""></option>
+                  ${users.map(
+                    (u) => html`<option value=${u.user_id}>${u.name}</option>`
+                  )}
+                </select>
+              </label>`
+            : ''}
+
+          <div class="pin-label">
+            ${this._t(this._stage === 1 ? 'new_pin' : 'confirm_pin')}
+          </div>
+          <div class="pin-display">${pinMask}</div>
+          <div class="keypad">
+            ${digits.map((d) =>
+              d === '⟲'
+                ? html`<button class="key action-btn del" @pointerdown=${(ev) => {
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    ev.currentTarget.blur();
+                    this._backspace();
+                  }}>⟲</button>`
+                : html`<button class="key action-btn" @pointerdown=${(ev) => {
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    ev.currentTarget.blur();
+                    this._addDigit(d);
+                  }}>${d}</button>`
+            )}
+          </div>
+
+          ${this._status
+            ? html`<div class="status ${
+                this._status === 'success' ? 'ok' : 'err'
+              }">${this._t(this._status)}</div>`
+            : ''}
+        </div>
+      </ha-card>
+    `;
+  }
+
+  static getConfigElement() {
+    return document.createElement('tally-set-pin-card-editor');
+  }
+
+  static getStubConfig() {
+    return {};
+  }
+
+  static styles = css`
+    .content {
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    ha-card {
+      position: relative;
+    }
+    .warn-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+      box-sizing: border-box;
+    }
+    .warn-box {
+      background: var(--card-background-color);
+      color: var(--primary-text-color);
+      border-radius: 12px;
+      padding: 16px;
+      text-align: center;
+      max-width: 300px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .form {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    select {
+      padding: 8px;
+      border-radius: 12px;
+      border: 1px solid var(--ha-card-border-color, #e0e0e0);
+      background: var(--card-background-color);
+      color: var(--primary-text-color);
+    }
+    .action-btn {
+      height: 40px;
+      border-radius: 12px;
+      border: none;
+      cursor: pointer;
+      background: var(--primary-color);
+      color: var(--text-primary-color, #fff);
+    }
+    .pin-label {
+      text-align: center;
+      font-weight: 600;
+    }
+    .pin-display {
+      display: flex;
+      gap: 12px;
+      height: 36px;
+      align-items: center;
+      justify-content: center;
+      margin: 8px 0;
+    }
+    .pin-dot {
+      width: 24px;
+      height: 24px;
+      border: 2px solid currentColor;
+      border-radius: 50%;
+      box-sizing: border-box;
+    }
+    .pin-dot.filled {
+      background-color: currentColor;
+    }
+    .keypad {
+      display: grid;
+      grid-template-columns: repeat(3, 44px);
+      gap: 8px;
+      justify-content: center;
+      margin-bottom: 8px;
+    }
+    .keypad .key {
+      font-size: 16px;
+      background: #2b2b2b;
+      color: #ddd;
+    }
+    .keypad .key.del {
+      background: var(--error-color, #b71c1c);
+      color: #fff;
+    }
+    .status {
+      font-size: 0.9em;
+    }
+    .status.ok {
+      color: var(--success-color, #2e7d32);
+    }
+    .status.err {
+      color: var(--error-color);
+    }
+  `;
+}
+
+customElements.define('tally-set-pin-card', TallySetPinCard);
+


### PR DESCRIPTION
## Summary
- add PIN management card for users and admins
- warn users not to use sensitive PINs before entry
- document new card and warning in English and German READMEs
- embed PIN card into main bundle and expose editor for Lovelace UI
- auto-populate admin user list, reuse keypad-style PIN entry, and call `tally_list.set_pin` service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc31c66b28832ebc926b9badb01216