### PR TITLE
Select admin user by default in pin reset card

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -4389,8 +4389,16 @@ class TallySetPinCard extends LitElement {
   }
 
   updated(changedProps) {
-    if (changedProps.has('hass') && !this.config.users) {
-      this._autoUsers = this._gatherUsers();
+    if (changedProps.has('hass')) {
+      if (!this.config.users) {
+        this._autoUsers = this._gatherUsers();
+      }
+      if (this._isAdmin && !this.selectedUserId) {
+        const ownId = this.hass?.user?.id;
+        if (ownId) {
+          this.selectedUserId = ownId;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Automatically select the current admin in the user menu when opening the pin reset card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3abee3a0832e974bf233ab8c0c5f