### PR TITLE
Color PIN hint button red and bump version to 07.09.2025

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "06.09.2025",
+  "version": "07.09.2025",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
 import { translate, fireEvent } from './tally-list-card.js';
-const CARD_VERSION = '06.09.2025';
+const CARD_VERSION = '07.09.2025';
 
 const TL_STRINGS = {
   en: {

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -317,7 +317,7 @@ function renderCoverLogin(card) {
     </div></div></ha-card>`;
 }
 
-const CARD_VERSION = '06.09.2025';
+const CARD_VERSION = '07.09.2025';
 
 const TL_STRINGS = {
   en: {
@@ -4591,6 +4591,9 @@ class TallySetPinCard extends LitElement {
       display: flex;
       flex-direction: column;
       gap: 12px;
+    }
+    .warn-box .action-btn {
+      background: red;
     }
     .form {
       display: flex;


### PR DESCRIPTION
## Summary
- style the PIN warning's acknowledgment button in red
- bump package and card versions to 07.09.2025

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd8fd4c46c832ea30c0cdf28d86f6b