### PR TITLE
feat: add lock for PIN set card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -123,6 +123,10 @@ type: custom:tally-set-pin-card
 
 Die Karte verwendet die gleiche Benutzerliste wie die Hauptkarte und benötigt normalerweise keine zusätzliche Konfiguration.
 
+Optionen:
+
+* **Sperrzeit (ms)** – Wartezeit nach dem Setzen einer neuen PIN (`5000` Standard).
+
 Zum Speichern der neuen PIN wird der Service `tally_list.set_pin` aufgerufen, z. B.:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ type: custom:tally-set-pin-card
 
 The card uses the same user list as the main Tally List card and normally requires no additional configuration.
 
+Options:
+
+* **lock_ms** – Lock duration in milliseconds after setting a new PIN (`5000` by default).
+
 It calls the `tally_list.set_pin` service to store the new code, e.g.:
 
 ```yaml


### PR DESCRIPTION
## Summary
- add configurable delay to temporarily disable the PIN set card after updating a PIN
- document new `lock_ms` option in English and German READMEs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd93d878b8832e9754db0b9b1c745d