### PR TITLE
Ensure PIN warning overlay covers card

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -4679,6 +4679,7 @@ class TallySetPinCard extends LitElement {
       justify-content: center;
       padding: 16px;
       box-sizing: border-box;
+      z-index: 2;
     }
     .warn-box {
       background: var(--card-background-color);


### PR DESCRIPTION
## Summary
- Fix PIN warning overlay layering so it appears above the PIN input circles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd98c48164832e95732ec5581a12ed