### PR TITLE
Reset PIN flow on mismatch

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -125,7 +125,7 @@ Die Karte verwendet die gleiche Benutzerliste wie die Hauptkarte und benötigt n
 
 Optionen:
 
-* **Sperrzeit (ms)** – Wartezeit nach dem Setzen einer neuen PIN (`5000` Standard).
+* **Sperrzeit (ms)** – Wartezeit nach jeder PIN-Eingabe (auch bei Fehlern) (`5000` Standard).
 
 Zum Speichern der neuen PIN wird der Service `tally_list.set_pin` aufgerufen, z. B.:
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The card uses the same user list as the main Tally List card and normally requir
 
 Options:
 
-* **lock_ms** – Lock duration in milliseconds after setting a new PIN (`5000` by default).
+* **lock_ms** – Lock duration in milliseconds after each PIN attempt (`5000` by default).
 
 It calls the `tally_list.set_pin` service to store the new code, e.g.:
 


### PR DESCRIPTION
## Summary
- Reset PIN entry to the first step when confirmation fails and apply lock timeout
- Show status-specific message during lock countdown
- Document lock_ms as applying after any PIN attempt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd99fac2c8832e8e9e85ac30f49282