### PR TITLE
Remove duplicate PIN mismatch message

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -4661,12 +4661,6 @@ class TallySetPinCard extends LitElement {
                   >${d}</button>`
             )}
           </div>
-
-          ${this._status
-            ? html`<div class="status ${
-                this._status === 'success' ? 'ok' : 'err'
-              }">${this._t(this._status)}</div>`
-            : ''}
         </div>
       </ha-card>
     `;
@@ -4796,15 +4790,6 @@ class TallySetPinCard extends LitElement {
     .keypad .key.del {
       background: var(--error-color, #b71c1c);
       color: #fff;
-    }
-    .status {
-      font-size: 0.9em;
-    }
-    .status.ok {
-      color: var(--success-color, #2e7d32);
-    }
-    .status.err {
-      color: var(--error-color);
     }
   `;
 }


### PR DESCRIPTION
## Summary
- remove redundant status element so the PIN mismatch message shows only in the timer overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9d394fb0832eb11ce8eed76e88c2