### PR TITLE
Align PIN card user selector with drink card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -126,6 +126,7 @@ Die Karte verwendet die gleiche Benutzerliste wie die Hauptkarte und benötigt n
 Optionen:
 
 * **Sperrzeit (ms)** – Wartezeit nach jeder PIN-Eingabe (auch bei Fehlern) (`5000` Standard).
+* **user_selector** – Layout der Nutzerauswahl: `list`, `tabs` oder `grid` (`list` standardmäßig).
 
 Zum Speichern der neuen PIN wird der Service `tally_list.set_pin` aufgerufen, z. B.:
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The card uses the same user list as the main Tally List card and normally requir
 Options:
 
 * **lock_ms** – Lock duration in milliseconds after each PIN attempt (`5000` by default).
+* **user_selector** – User selection layout: `list`, `tabs`, or `grid` (`list` by default).
 
 It calls the `tally_list.set_pin` service to store the new code, e.g.:
 


### PR DESCRIPTION
## Summary
- Allow the Set PIN card to render the same user selector layouts as the drink card
- Add configurable `user_selector` option and editor support
- Document `user_selector` option for the PIN card

## Testing
- `node --check tally-list-card.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda1018c20832e9599fa18772dc810