### PR TITLE
feat: make pin warning configurable

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -115,7 +115,7 @@ comment_presets:
 ## PIN-Karte
 
 Nutzer können ihre eigene 4-stellige PIN setzen oder zurücksetzen. Administratoren können für jeden Nutzer die PIN festlegen. Die Karte kann über den Lovelace-Karteneditor hinzugefügt werden.
-Beim Öffnen der Karte erscheint ein Hinweis, keine wichtige PIN (z. B. die der Bankkarte) zu verwenden, da nicht garantiert werden kann, dass sie nicht entwendet wird.
+Beim Öffnen der Karte kann ein konfigurierbarer Hinweis anzeigen, keine wichtige PIN (z. B. die der Bankkarte) zu verwenden. Wird der Text leer gelassen, wird kein Hinweis gezeigt.
 
 ```yaml
 type: custom:tally-set-pin-card
@@ -127,6 +127,7 @@ Optionen:
 
 * **Sperrzeit (ms)** – Wartezeit nach jeder PIN-Eingabe (auch bei Fehlern) (`5000` Standard).
 * **user_selector** – Layout der Nutzerauswahl: `list`, `tabs` oder `grid` (`list` standardmäßig).
+* **pin_warning** – Warntext beim Öffnen der Karte. Leerer Text blendet den Hinweis aus (Standard warnt vor wichtigen PINs).
 
 Zum Speichern der neuen PIN wird der Service `tally_list.set_pin` aufgerufen, z. B.:
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ comment_presets:
 ## PIN Set Card
 
 Allow users to set or reset their 4-digit PIN. Administrators can select any user and update the PIN for them. The card is available in the Lovelace card picker.
-When opened, a warning reminds users not to use important PINs such as their bank card PIN, since its security cannot be guaranteed.
+When opened, a configurable warning can remind users not to use important PINs such as their bank card PIN. Leave the warning text empty to disable it.
 
 ```yaml
 type: custom:tally-set-pin-card
@@ -128,6 +128,7 @@ Options:
 
 * **lock_ms** – Lock duration in milliseconds after each PIN attempt (`5000` by default).
 * **user_selector** – User selection layout: `list`, `tabs`, or `grid` (`list` by default).
+* **pin_warning** – Warning text shown when opening the card. Set to an empty string to hide the warning (defaults to a caution about important PINs).
 
 It calls the `tally_list.set_pin` service to store the new code, e.g.:
 


### PR DESCRIPTION
## Summary
- allow customizing PIN warning text via `pin_warning` option
- hide PIN warning when option is empty
- document new option in English and German READMEs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda82ae178832ea9c51894351a5f25