### PR TITLE
feat: make pin warning configurable

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -115,7 +115,7 @@ comment_presets:
 ## PIN-Karte
 
 Nutzer können ihre eigene 4-stellige PIN setzen oder zurücksetzen. Administratoren können für jeden Nutzer die PIN festlegen. Die Karte kann über den Lovelace-Karteneditor hinzugefügt werden.
-Beim Öffnen der Karte erscheint ein Hinweis, keine wichtige PIN (z. B. die der Bankkarte) zu verwenden, da nicht garantiert werden kann, dass sie nicht entwendet wird.
+Beim Öffnen der Karte kann ein konfigurierbarer Hinweis anzeigen, keine wichtige PIN (z. B. die der Bankkarte) zu verwenden. Wird der Text leer gelassen, wird kein Hinweis gezeigt.
 
 ```yaml
 type: custom:tally-set-pin-card
@@ -127,6 +127,7 @@ Optionen:
 
 * **Sperrzeit (ms)** – Wartezeit nach jeder PIN-Eingabe (auch bei Fehlern) (`5000` Standard).
 * **user_selector** – Layout der Nutzerauswahl: `list`, `tabs` oder `grid` (`list` standardmäßig).
+* **pin_warning** – Warntext beim Öffnen der Karte. Unterstützt Zeilenumbrüche und einfache Markdown-Formatierung für _kursiv_, **fett** und __unterstrichen__. Leerer Text blendet den Hinweis aus (Standard warnt vor wichtigen PINs).
 
 Zum Speichern der neuen PIN wird der Service `tally_list.set_pin` aufgerufen, z. B.:
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ comment_presets:
 ## PIN Set Card
 
 Allow users to set or reset their 4-digit PIN. Administrators can select any user and update the PIN for them. The card is available in the Lovelace card picker.
-When opened, a warning reminds users not to use important PINs such as their bank card PIN, since its security cannot be guaranteed.
+When opened, a configurable warning can remind users not to use important PINs such as their bank card PIN. Leave the warning text empty to disable it.
 
 ```yaml
 type: custom:tally-set-pin-card
@@ -128,6 +128,7 @@ Options:
 
 * **lock_ms** – Lock duration in milliseconds after each PIN attempt (`5000` by default).
 * **user_selector** – User selection layout: `list`, `tabs`, or `grid` (`list` by default).
+* **pin_warning** – Warning text shown when opening the card. Supports line breaks and simple Markdown for _italic_, **bold**, and __underline__. Set to an empty string to hide the warning (defaults to a caution about important PINs).
 
 It calls the `tally_list.set_pin` service to store the new code, e.g.:
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -24,6 +24,19 @@ export function fireEvent(node, type, detail = {}, options = {}) {
   );
 }
 
+function formatWarning(text) {
+  const escape = (str) =>
+    str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  return escape(text)
+    .replace(/\*\*([\s\S]+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/__([\s\S]+?)__/g, '<u>$1</u>')
+    .replace(/_([\s\S]+?)_/g, '<em>$1</em>')
+    .replace(/\n/g, '<br>');
+}
+
 // ---- Public Session Handling ----
 const PUBLIC_SESSION = {
   isPublic: false,
@@ -4306,6 +4319,7 @@ const PIN_EDITOR_STRINGS = {
     grouped_breaks: 'Grouped breaks',
     show_all_tab: 'Show "All" tab',
     grid_columns: 'Grid columns (0 = auto)',
+    warning_text: 'Warning message (empty to disable)',
     debug: 'Debug',
     language: 'Language',
     auto: 'Auto',
@@ -4325,6 +4339,7 @@ const PIN_EDITOR_STRINGS = {
     grouped_breaks: 'Gruppierte Bereiche',
     show_all_tab: 'Tab "Alle" anzeigen',
     grid_columns: 'Spalten (0 = automatisch)',
+    warning_text: 'Warnhinweis (leer lassen zum Deaktivieren)',
     debug: 'Debug',
     language: 'Sprache',
     auto: 'Auto',
@@ -4364,6 +4379,14 @@ class TallySetPinCardEditor extends LitElement {
       tabs,
       grid,
     };
+    if (this._config.pin_warning === undefined) {
+      this._config.pin_warning = translate(
+        this.hass,
+        this._config?.language,
+        PIN_STRINGS,
+        'warning'
+      );
+    }
   }
 
   _lockChanged(ev) {
@@ -4418,6 +4441,13 @@ class TallySetPinCardEditor extends LitElement {
     );
   }
 
+  _warningChanged(ev) {
+    this._config = { ...this._config, pin_warning: ev.target.value };
+    this.dispatchEvent(
+      new CustomEvent('config-changed', { detail: { config: this._config } })
+    );
+  }
+
   render() {
     const idLock = this._fid('lock-ms');
     const idUserSelector = this._fid('user-selector');
@@ -4425,6 +4455,7 @@ class TallySetPinCardEditor extends LitElement {
     const idGroupedBreaks = this._fid('grouped-breaks');
     const idShowAllTab = this._fid('show-all-tab');
     const idGridColumns = this._fid('grid-columns');
+    const idWarning = this._fid('pin-warning');
     const idLanguage = this._fid('language');
     return html`
       <div class="form">
@@ -4441,6 +4472,20 @@ class TallySetPinCardEditor extends LitElement {
           .value=${this._config.lock_ms}
           @input=${this._lockChanged}
         />
+      </div>
+      <div class="form">
+        <label for="${idWarning}">${translate(
+          this.hass,
+          this._config?.language,
+          PIN_EDITOR_STRINGS,
+          'warning_text'
+        )}</label>
+        <textarea
+          id="${idWarning}"
+          name="pin_warning"
+          .value=${this._config.pin_warning}
+          @input=${this._warningChanged}
+        ></textarea>
       </div>
       <div class="form">
         <label for="${idUserSelector}">${translate(
@@ -4638,9 +4683,13 @@ class TallySetPinCardEditor extends LitElement {
       padding: 16px;
     }
     input,
-    select {
+    select,
+    textarea {
       width: 100%;
       box-sizing: border-box;
+    }
+    textarea {
+      min-height: 60px;
     }
     details.debug {
       padding: 0 16px 16px;
@@ -4762,10 +4811,17 @@ class TallySetPinCard extends LitElement {
     };
     this.config.tabs = tabs;
     this.config.grid = grid;
+    this._showWarn = this._warningText !== '';
   }
 
   _t(key) {
     return translate(this.hass, this.config.language, PIN_STRINGS, key);
+  }
+
+  get _warningText() {
+    return typeof this.config?.pin_warning === 'string'
+      ? this.config.pin_warning
+      : this._t('warning');
   }
 
   get _users() {
@@ -4947,17 +5003,20 @@ class TallySetPinCard extends LitElement {
     const pinMask = Array.from({ length: 4 }, (_, i) =>
       html`<span class="pin-dot ${this._buffer.length > i ? 'filled' : ''}"></span>`
     );
+    const warningHtml = formatWarning(this._warningText);
     return html`
       <ha-card>
         ${this._showWarn
-          ? html`<div class="warn-overlay">
-              <div class="warn-box">
-                <p>${this._t('warning')}</p>
-                <button class="action-btn" @click=${() => (this._showWarn = false)}>
-                  ${this._t('ok')}
-                </button>
-              </div>
-            </div>`
+          ? this._warningText
+            ? html`<div class="warn-overlay">
+                <div class="warn-box">
+                  <p .innerHTML=${warningHtml}></p>
+                  <button class="action-btn" @click=${() => (this._showWarn = false)}>
+                    ${this._t('ok')}
+                  </button>
+                </div>
+              </div>`
+            : ''
           : ''}
         <div class="content">
           ${isAdmin ? userMenu : ''}


### PR DESCRIPTION
## Summary
- allow customizing PIN warning text via `pin_warning` option
- hide PIN warning when option is empty
- support line breaks and simple Markdown formatting
- document new option in English and German READMEs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda82ae178832ea9c51894351a5f25