### PR TITLE
Update default PIN warning message

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -127,7 +127,7 @@ Optionen:
 
 * **Sperrzeit (ms)** – Wartezeit nach jeder PIN-Eingabe (auch bei Fehlern) (`5000` Standard).
 * **user_selector** – Layout der Nutzerauswahl: `list`, `tabs` oder `grid` (`list` standardmäßig).
-* **pin_warning** – Warntext beim Öffnen der Karte. Unterstützt Zeilenumbrüche und einfache Markdown-Formatierung für _kursiv_, **fett** und __unterstrichen__. Leerer Text blendet den Hinweis aus (Standard warnt vor wichtigen PINs).
+* **pin_warning** – Warntext beim Öffnen der Karte. Unterstützt Zeilenumbrüche und einfache Markdown-Formatierung für _kursiv_, **fett** und __unterstrichen__. Leerer Text blendet den Hinweis aus. Standardtext: "**Bitte keine wichtige PIN (z. B. die der Bankkarte) verwenden.** PINs werden zwar verschlüsselt gespeichert, dennoch kann nicht garantiert werden, dass sie nicht in falsche Hände gerät."
 
 Zum Speichern der neuen PIN wird der Service `tally_list.set_pin` aufgerufen, z. B.:
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Options:
 
 * **lock_ms** – Lock duration in milliseconds after each PIN attempt (`5000` by default).
 * **user_selector** – User selection layout: `list`, `tabs`, or `grid` (`list` by default).
-* **pin_warning** – Warning text shown when opening the card. Supports line breaks and simple Markdown for _italic_, **bold**, and __underline__. Set to an empty string to hide the warning (defaults to a caution about important PINs).
+* **pin_warning** – Warning text shown when opening the card. Supports line breaks and simple Markdown for _italic_, **bold**, and __underline__. Set to an empty string to hide the warning. Default: "**Do not use an important PIN (e.g., your bank card PIN).** PINs are stored encrypted, but there is no guarantee they will not fall into the wrong hands."
 
 It calls the `tally_list.set_pin` service to store the new code, e.g.:
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -4723,7 +4723,7 @@ const PIN_STRINGS = {
     invalid: 'Enter 4 digits',
     error: 'Failed to set PIN',
     warning:
-      'Do not use an important PIN (e.g., your bank card PIN); its security cannot be guaranteed.',
+      '**Do not use an important PIN (e.g., your bank card PIN).**\n\nPINs are stored encrypted, but there is no guarantee they will not fall into the wrong hands.',
     ok: 'Got it',
   },
   de: {
@@ -4738,7 +4738,7 @@ const PIN_STRINGS = {
     invalid: '4 Ziffern eingeben',
     error: 'PIN konnte nicht gesetzt werden',
     warning:
-      'Bitte keine wichtige PIN (z. B. die der Bankkarte) verwenden, da nicht gewährleistet werden kann, dass sie nicht gestohlen wird.',
+      '**Bitte keine wichtige PIN (z. B. die der Bankkarte) verwenden.**\n\nPINs werden zwar verschlüsselt gespeichert, dennoch kann nicht garantiert werden, dass sie nicht in falsche Hände gerät.',
     ok: 'Verstanden',
   },
 };


### PR DESCRIPTION
## Summary
- emphasize encryption disclaimer and bold first sentence in default PIN warning message
- document new default warning text in both English and German READMEs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdab38935c832e9d5d153f510074ab