### PR TITLE
feat: optional shortening of user names

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -60,6 +60,7 @@ Folgende Optionen stehen im UI zur Verfügung:
 * **Entfernen-Menü anzeigen** – Ein-/Ausblenden des Menüs zum Entfernen.
 * **Schrittweiten-Auswahl anzeigen** – Schaltflächen zur Auswahl der Schrittweite (1, 3, 5, 10) anzeigen.
 * **Nur sich selbst zeigen** – Auswahl auch für Admins auf den eingeloggten Nutzer beschränken.
+* **Namen kürzen** – Namen in der Auswahl abkürzen, bei Bedarf mit weiteren Buchstaben eindeutig halten.
 * **Sprache** – **Auto**, **Deutsch** oder **English** erzwingen.
 * **Version** – Zeigt die installierte Version an.
 
@@ -81,6 +82,7 @@ Optionen:
 * **max_entries** – Anzahl angezeigter Nutzer begrenzen (`0` = unbegrenzt).
 * **hide_free** – Nutzer ohne offenen Betrag ausblenden.
 * **show_copy** – Schaltfläche **Tabelle kopieren** anzeigen.
+* **shorten_user_names** – Namen in der Tabelle abkürzen.
 
 ## Freigetränke-Karte
 
@@ -99,6 +101,7 @@ Optionen:
 * **free_drinks_timer_seconds** – Auto-Reset-Timer in Sekunden (`0` = aus).
 * **free_drinks_per_item_limit** – Limit je Getränk (`0` = aus).
 * **free_drinks_total_limit** – Gesamtlimit (`0` = aus).
+* **Namen kürzen** – Namen in der Auswahl abkürzen.
 
 Beispiel:
 
@@ -127,6 +130,7 @@ Optionen:
 
 * **Sperrzeit (ms)** – Wartezeit nach jeder PIN-Eingabe (auch bei Fehlern) (`5000` Standard).
 * **user_selector** – Layout der Nutzerauswahl: `list`, `tabs` oder `grid` (`list` standardmäßig).
+* **Namen kürzen** – Namen in der Auswahl abkürzen.
 * **pin_warning** – Warntext beim Öffnen der Karte. Unterstützt Zeilenumbrüche und einfache Markdown-Formatierung für _kursiv_, **fett** und __unterstrichen__. Leerer Text blendet den Hinweis aus. Standardtext: "**Bitte keine wichtige PIN (z. B. die der Bankkarte) verwenden.** PINs werden zwar verschlüsselt gespeichert, dennoch kann nicht garantiert werden, dass sie nicht in falsche Hände gerät."
 
 Zum Speichern der neuen PIN wird der Service `tally_list.set_pin` aufgerufen, z. B.:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The card offers the following options in the UI:
 * **Show remove menu** – Enable/disable the remove-drink dropdown.
 * **Show step selection** – Show buttons to select the step size (1, 3, 5, 10).
 * **Only show self** – Limit selection to the logged‑in user even for admins.
+* **Shorten user names** – Abbreviate names in the selector while keeping them unique.
 * **User selector** – Choose between **list**, **tabs**, or **grid** for selecting users.
 * **Language** – Force **Auto**, **Deutsch**, or **English**.
 * **Version** – Display the installed version.
@@ -82,6 +83,7 @@ Options:
 * **max_entries** – Limit how many users are shown (`0` = no limit).
 * **hide_free** – Hide users who owe nothing.
 * **show_copy** – Show the "Tabelle kopieren" button.
+* **shorten_user_names** – Abbreviate user names in the table.
 
 ## Free Drinks Card
 
@@ -100,6 +102,7 @@ Options:
 * **free_drinks_timer_seconds** – Auto-reset timer in seconds (`0` to disable).
 * **free_drinks_per_item_limit** – Maximum free drinks per item (`0` to disable).
 * **free_drinks_total_limit** – Maximum free drinks overall (`0` to disable).
+* **shorten_user_names** – Abbreviate user names in the selector.
 
 Example:
 
@@ -128,6 +131,7 @@ Options:
 
 * **lock_ms** – Lock duration in milliseconds after each PIN attempt (`5000` by default).
 * **user_selector** – User selection layout: `list`, `tabs`, or `grid` (`list` by default).
+* **shorten_user_names** – Abbreviate user names in the selector.
 * **pin_warning** – Warning text shown when opening the card. Supports line breaks and simple Markdown for _italic_, **bold**, and __underline__. Set to an empty string to hide the warning. Default: "**Do not use an important PIN (e.g., your bank card PIN).** PINs are stored encrypted, but there is no guarantee they will not fall into the wrong hands."
 
 It calls the `tally_list.set_pin` service to store the new code, e.g.:

--- a/tally-list-card-editor.js
+++ b/tally-list-card-editor.js
@@ -13,6 +13,7 @@ const TL_STRINGS = {
     show_step_select: 'Show step selection',
     show_all_users: 'Show all users',
     show_inactive_drinks: 'Show inactive drinks',
+    shorten_user_names: 'Shorten user names',
     debug: 'Debug',
     language: 'Language',
     auto: 'Auto',
@@ -40,6 +41,7 @@ const TL_STRINGS = {
     show_step_select: 'Schrittweiten-Auswahl anzeigen',
     show_all_users: 'Alle Nutzer anzeigen',
     show_inactive_drinks: 'Inaktive Getränke anzeigen',
+    shorten_user_names: 'Namen kürzen',
     debug: 'Debug',
     language: 'Sprache',
     auto: 'Auto',
@@ -89,6 +91,7 @@ class TallyListCardEditor extends LitElement {
       show_step_select: true,
       show_all_users: false,
       show_inactive_drinks: false,
+      shorten_user_names: false,
       language: 'auto',
       user_selector: 'list',
       ...config,
@@ -152,6 +155,12 @@ class TallyListCardEditor extends LitElement {
         <label>
           <input type="checkbox" .checked=${this._config.only_self} @change=${this._selfChanged} />
           ${this._t('only_self')}
+        </label>
+      </div>
+      <div class="form">
+        <label>
+          <input type="checkbox" .checked=${this._config.shorten_user_names} @change=${this._shortNamesChanged} />
+          ${this._t('shorten_user_names')}
         </label>
       </div>
       <div class="form">
@@ -257,6 +266,11 @@ class TallyListCardEditor extends LitElement {
 
   _selfChanged(ev) {
     this._config = { ...this._config, only_self: ev.target.checked };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _shortNamesChanged(ev) {
+    this._config = { ...this._config, shorten_user_names: ev.target.checked };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 


### PR DESCRIPTION
## Summary
- allow optional shortening of user names in selectors and ranking tables
- provide unique abbreviations by appending letters from last name and slug
- document and expose `shorten_user_names` option across all cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdad9c3c0c832e8b42b36c43074dcd