### PR TITLE
Fix names shortening checkbox layout in PIN set card editor

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -4589,19 +4589,21 @@ class TallySetPinCardEditor extends LitElement {
         />
       </div>
       <div class="form">
-        <input
-          id="${idShortNames}"
-          name="shorten_user_names"
-          type="checkbox"
-          .checked=${this._config.shorten_user_names}
-          @change=${this._shortNamesChanged}
-        />
-        <label for="${idShortNames}">${translate(
-          this.hass,
-          this._config?.language,
-          PIN_EDITOR_STRINGS,
-          'shorten_user_names'
-        )}</label>
+        <label>
+          <input
+            id="${idShortNames}"
+            name="shorten_user_names"
+            type="checkbox"
+            .checked=${this._config.shorten_user_names}
+            @change=${this._shortNamesChanged}
+          />
+          ${translate(
+            this.hass,
+            this._config?.language,
+            PIN_EDITOR_STRINGS,
+            'shorten_user_names'
+          )}
+        </label>
       </div>
       <div class="form">
         <label for="${idWarning}">${translate(


### PR DESCRIPTION
## Summary
- Align "Namen kürzen" checkbox layout in set PIN card editor with the regular drink card editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb0cc2f9c832ebde1bcfd6279b469