### PR TITLE
Fix shorten names checkbox alignment in PIN card editor

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -4814,6 +4814,11 @@ class TallySetPinCardEditor extends LitElement {
     .form {
       padding: 16px;
     }
+    .form input[type='checkbox'] {
+      width: auto;
+      display: inline-block;
+      margin-right: 8px;
+    }
     input:not([type='checkbox']),
     select,
     textarea {


### PR DESCRIPTION
## Summary
- Correct placement of the "shorten user names" checkbox in the Set PIN card editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb36abaf4832ea1b3376354255678