### PR TITLE
Show copied message on copy button

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -2402,7 +2402,11 @@ class TallyDueRankingCard extends LitElement {
     }
   `;
 
-  async firstUpdated() {}
+  firstUpdated() {
+    if (!this.selectedUserId) {
+      this.selectedUserId = this.hass?.user?.id || '';
+    }
+  }
 
   setConfig(config) {
     this.config = {
@@ -3682,8 +3686,9 @@ class TallyListFreeDrinksCard extends LitElement {
     return 3;
   }
 
-  firstUpdated() {
-    if (!this.selectedUserId) this.selectedUserId = this.hass?.user?.id || '';
+  updated(changed) {
+    super.updated?.(changed);
+    if (this._copyBtnWidth) return;
     const copyBtn = this.renderRoot?.querySelector('.button-row .btn--neutral');
     if (copyBtn) {
       const normalWidth = copyBtn.offsetWidth;

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -2373,6 +2373,7 @@ class TallyDueRankingCard extends LitElement {
       margin-top: 8px;
     }
     .ranking-card .btn {
+      box-sizing: border-box;
       height: var(--row-h);
       border-radius: 12px;
       padding: 0 16px;
@@ -3685,7 +3686,15 @@ class TallyListFreeDrinksCard extends LitElement {
     if (!this.selectedUserId) this.selectedUserId = this.hass?.user?.id || '';
     const copyBtn = this.renderRoot?.querySelector('.button-row .btn--neutral');
     if (copyBtn) {
-      this._copyBtnWidth = copyBtn.offsetWidth;
+      const normalWidth = copyBtn.offsetWidth;
+      const tmp = copyBtn.cloneNode(true);
+      tmp.textContent = this._t('copied');
+      tmp.style.position = 'absolute';
+      tmp.style.visibility = 'hidden';
+      this.renderRoot.appendChild(tmp);
+      const copiedWidth = tmp.offsetWidth;
+      tmp.remove();
+      this._copyBtnWidth = Math.max(normalWidth, copiedWidth);
     }
   }
 

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -381,6 +381,7 @@ const TL_STRINGS = {
     hide_free: 'Hide people without amount',
     show_step_select: 'Show step selection',
     copy_table: 'Copy table',
+    copied: 'Copied!',
     reset_all: 'Reset all tallies',
     show_reset_everyone: 'Show reset button for everyone',
     max_entries: 'Maximum entries (0 = all)',
@@ -450,6 +451,7 @@ const TL_STRINGS = {
     hide_free: 'Personen ohne Betrag ausblenden',
     show_step_select: 'Schrittweiten-Auswahl anzeigen',
     copy_table: 'Tabelle kopieren',
+    copied: 'Kopiert!',
     reset_all: 'Alle Striche zurücksetzen',
     show_reset_everyone: 'Für jeden Reset-Button anzeigen',
     max_entries: 'Maximale Einträge (0 = alle)',
@@ -2274,12 +2276,15 @@ class TallyDueRankingCard extends LitElement {
     _currency: { state: true },
     _sortBy: { state: true },
     _tallyAdmins: { state: true },
+    _copyDisabled: { state: true },
+    _copyBtnWidth: { state: true },
   };
 
   _tallyAdmins = [];
   _hass = null;
   _deps = new Set();
   _fmtCache = new Map();
+  _copyBtnWidth = 0;
 
   constructor() {
     super();
@@ -2292,6 +2297,7 @@ class TallyDueRankingCard extends LitElement {
     }
     this._bootstrapped = true;
     this._loading = false;
+    this._copyDisabled = false;
   }
 
   _fid(key) {
@@ -2388,6 +2394,10 @@ class TallyDueRankingCard extends LitElement {
     .ranking-card .btn:active {
       filter: brightness(0.9);
       transform: scale(0.97);
+    }
+    .ranking-card .btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
     }
   `;
 
@@ -2508,7 +2518,12 @@ class TallyDueRankingCard extends LitElement {
       : '';
     const buttons = [];
     if (this.config.show_copy !== false) {
-      buttons.push(html`<button class="btn btn--neutral" @click=${this._copyRanking}>${this._t('copy_table')}</button>`);
+      buttons.push(html`<button
+          class="btn btn--neutral"
+          style=${this._copyBtnWidth ? `width:${this._copyBtnWidth}px` : ''}
+          @click=${this._copyRanking}
+          ?disabled=${this._copyDisabled}
+        >${this._copyDisabled ? this._t('copied') : this._t('copy_table')}</button>`);
     }
     if ((isAdmin || this.config.show_reset_everyone) && this.config.show_reset !== false) {
       buttons.push(html`<button class="btn btn--danger" @click=${this._resetAllTallies}>${this._t('reset_all')}</button>`);
@@ -2806,14 +2821,11 @@ class TallyDueRankingCard extends LitElement {
       lines.push(`${this._t('total')}: ${this._formatPrice(total)} ${this._currency}`);
     }
     const text = lines.join('\n');
-    const notify = () => {
-      this.dispatchEvent(
-        new CustomEvent('hass-notification', {
-          detail: { message: this._t('copy_success') },
-          bubbles: true,
-          composed: true,
-        })
-      );
+    const onCopy = () => {
+      this._copyDisabled = true;
+      setTimeout(() => {
+        this._copyDisabled = false;
+      }, 3000);
     };
     const legacyCopy = () => {
       const textarea = document.createElement('textarea');
@@ -2823,13 +2835,13 @@ class TallyDueRankingCard extends LitElement {
       textarea.focus();
       textarea.select();
       try {
-        if (document.execCommand('copy')) notify();
+        if (document.execCommand('copy')) onCopy();
       } finally {
         document.body.removeChild(textarea);
       }
     };
     if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(notify).catch(legacyCopy);
+      navigator.clipboard.writeText(text).then(onCopy).catch(legacyCopy);
     } else {
       legacyCopy();
     }
@@ -3671,6 +3683,10 @@ class TallyListFreeDrinksCard extends LitElement {
 
   firstUpdated() {
     if (!this.selectedUserId) this.selectedUserId = this.hass?.user?.id || '';
+    const copyBtn = this.renderRoot?.querySelector('.button-row .btn--neutral');
+    if (copyBtn) {
+      this._copyBtnWidth = copyBtn.offsetWidth;
+    }
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
## Summary
- Replace copy notification toast with in-place button feedback
- Disable copy button for three seconds after a successful copy and show "Kopiert!"
- Keep copy button width fixed when text changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbdef313c832e8f9d1ec84862cb64