### PR TITLE
Color invalid PIN message red

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1616,6 +1616,7 @@ class TallyListCard extends LitElement {
       justify-content: center;
       z-index: 1;
       background: var(--card-background-color, #fff);
+      color: var(--error-color, #d9534f);
     }
     .pin-dot {
       width: 24px;


### PR DESCRIPTION
## Summary
- Display PIN lock message in red when a PIN entry is invalid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc4f7db08832eaf196cff02c807e1