### PR TITLE
style: show pin lock message in red

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1617,6 +1617,7 @@ class TallyListCard extends LitElement {
       z-index: 1;
       background: var(--card-background-color, #fff);
       text-align: center;
+      color: var(--error-color, #d9534f);
     }
     .pin-dot {
       width: 24px;


### PR DESCRIPTION
## Summary
- make PIN lock message red for better visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc726d288832ebe4dd6906f8ea559