### PR TITLE
Grey out set PIN keypad during lock timer

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -5425,6 +5425,10 @@ class TallySetPinCard extends LitElement {
       background: var(--error-color, #b71c1c);
       color: #fff;
     }
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
   `;
 }
 


### PR DESCRIPTION
## Summary
- grey out keypad buttons in set PIN card when lock timer is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc7638f38832e969d8cfe2ad5f000