### PR TITLE
Hide PIN warning when user not found

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -5175,7 +5175,7 @@ class TallySetPinCard extends LitElement {
     const warningHtml = formatWarning(this._warningText);
     return html`
       <ha-card>
-        ${this._showWarn
+        ${this._showWarn && userFound
           ? this._warningText
             ? html`<div class="warn-overlay">
                 <div class="warn-box">


### PR DESCRIPTION
## Summary
- Display the PIN warning overlay only when a valid user is present, preventing the warning from appearing alongside "User not found" messages.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcb29c778832e940631b168b13af7