### PR TITLE
Add only-self option to PIN card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -133,6 +133,7 @@ Optionen:
 * **max_width** – Maximale Kartenbreite in Pixeln (`500` Standard).
 * **user_selector** – Layout der Nutzerauswahl: `list`, `tabs` oder `grid` (`list` standardmäßig).
 * **Namen kürzen** – Namen in der Auswahl abkürzen.
+* **only_self** – Nur den eigenen Nutzer anzeigen, auch für Admins.
 * **pin_warning** – Warntext beim Öffnen der Karte. Unterstützt Zeilenumbrüche und einfache Markdown-Formatierung für _kursiv_, **fett** und __unterstrichen__. Leerer Text blendet den Hinweis aus. Standardtext: "**Bitte keine wichtige PIN (z. B. die der Bankkarte) verwenden.** PINs werden zwar verschlüsselt gespeichert, dennoch kann nicht garantiert werden, dass sie nicht in falsche Hände gerät."
 
 Zum Speichern der neuen PIN wird der Service `tally_list.set_pin` aufgerufen, z. B.:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Options:
 * **max_width** – Maximum card width in pixels (`500` by default).
 * **user_selector** – User selection layout: `list`, `tabs`, or `grid` (`list` by default).
 * **shorten_user_names** – Abbreviate user names in the selector.
+* **only_self** – Only show the current user even for admins.
 * **pin_warning** – Warning text shown when opening the card. Supports line breaks and simple Markdown for _italic_, **bold**, and __underline__. Set to an empty string to hide the warning. Default: "**Do not use an important PIN (e.g., your bank card PIN).** PINs are stored encrypted, but there is no guarantee they will not fall into the wrong hands."
 
 It calls the `tally_list.set_pin` service to store the new code, e.g.:


### PR DESCRIPTION
## Summary
- allow PIN card to limit admins to their own user
- document new `only_self` option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c45b72a478832e92a9808f626acffe