### PR TITLE
Use tally-list-card update slug

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -14,6 +14,7 @@ Eine Lovelace-Karte für Home Assistant, die Getränkezähler pro Nutzer anzeigt
 1. Dieses Repository in HACS als **Custom Repository** (Kategorie **Lovelace**) hinzufügen.
 2. **Tally List Card** aus dem HACS‑Store installieren.
 3. HACS hält die Dateien aktuell. Die Karte **Strichliste Freigetränke** ist automatisch enthalten und benötigt keine zusätzliche Ressource.
+4. HACS erstellt die Update-Entität `update.tally_list_card_update` (zuvor `update.drink_counter_card_update`). Falls weiterhin die alte Entität erscheint, Repository in HACS entfernen und neu hinzufügen.
 
 ### Manuell
 1. `tally-list-card.js` in das `www`‑Verzeichnis von Home Assistant kopieren.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ A Lovelace card for Home Assistant that displays drink tallies per user and allo
 ## Installation
 
 ### Via HACS
-1. Add this repository as a **Custom Repository** in HACS (category **Lovelace**). 
+1. Add this repository as a **Custom Repository** in HACS (category **Lovelace**).
 2. Install **Tally List Card** from the HACS store.
 3. HACS keeps the files up to date. The Free Drinks Card is included automatically and requires no extra resource.
+4. HACS creates the update entity `update.tally_list_card_update` (previously `update.drink_counter_card_update`). If you still see the old entity, remove and re-add the repository in HACS.
 
 ### Manual
 1. Copy `tally-list-card.js` to your Home Assistant `www` directory.

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Tally List Card",
+  "name": "tally-list-card",
   "content_in_root": true,
   "filename": "tally-list-card.js",
   "render_readme": true

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ha-tally-list-lovelace",
+  "name": "tally-list-card",
   "version": "12.09.25",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",


### PR DESCRIPTION
## Summary
- Rename HACS metadata to `tally-list-card` so the update entity uses the new slug
- Note how to resolve lingering `update.drink_counter_card_update` entities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c45bc1c360832ebc87685ee8fb41b5