### PR TITLE
Add only_self option to Free Drinks card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -102,6 +102,7 @@ Optionen:
 * **free_drinks_timer_seconds** – Auto-Reset-Timer in Sekunden (`0` = aus).
 * **free_drinks_per_item_limit** – Limit je Getränk (`0` = aus).
 * **free_drinks_total_limit** – Gesamtlimit (`0` = aus).
+* **only_self** – Nur den eigenen Nutzer anzeigen, auch für Admins.
 * **Namen kürzen** – Namen in der Auswahl abkürzen.
 
 Beispiel:

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Options:
 * **free_drinks_timer_seconds** – Auto-reset timer in seconds (`0` to disable).
 * **free_drinks_per_item_limit** – Maximum free drinks per item (`0` to disable).
 * **free_drinks_total_limit** – Maximum free drinks overall (`0` to disable).
+* **only_self** – Only show the current user even for admins.
 * **shorten_user_names** – Abbreviate user names in the selector.
 
 Example:

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -3139,6 +3139,7 @@ class TallyListFreeDrinksCardEditor extends LitElement {
       max_width: '500px',
       language: 'auto',
       user_selector: 'list',
+      only_self: false,
       shorten_user_names: false,
       ...(config || {}),
       comment_presets: presets,
@@ -3212,6 +3213,12 @@ class TallyListFreeDrinksCardEditor extends LitElement {
               <label class="switch">
                 ${t(this.hass, this._config.language, 'shorten_user_names')}
                 <ha-switch .checked=${this._config.shorten_user_names} @change=${this._shortNamesChanged}></ha-switch>
+              </label>
+            </div>
+            <div class="form">
+              <label class="switch">
+                ${t(this.hass, this._config.language, 'only_self')}
+                <ha-switch .checked=${this._config.only_self} @change=${this._selfChanged}></ha-switch>
               </label>
             </div>
             <div class="form">
@@ -3373,6 +3380,11 @@ class TallyListFreeDrinksCardEditor extends LitElement {
       ...this._config,
       free_drinks_total_limit: isNaN(value) ? 0 : value,
     };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _selfChanged(ev) {
+    this._config = { ...this._config, only_self: ev.target.checked };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 
@@ -3591,6 +3603,7 @@ class TallyListFreeDrinksCard extends LitElement {
       max_width: '500px',
       language: 'auto',
       user_selector: 'list',
+      only_self: false,
       ...(config || {}),
       comment_presets: presets,
       tabs,
@@ -4036,9 +4049,10 @@ class TallyListFreeDrinksCard extends LitElement {
     const showPrices = this.config.show_prices !== false;
     const mode = this.config.user_selector || 'list';
     const isAdmin = this._isAdmin;
+    const showAdmin = isAdmin && !this.config.only_self;
     const visibleUsers = this.isPublic
       ? allUsers
-      : isAdmin
+      : showAdmin
       ? allUsers
       : allUsers.filter((u) => u.user_id === this.hass?.user?.id);
     if (this.isPublic && this.sessionReady) {
@@ -4053,7 +4067,7 @@ class TallyListFreeDrinksCard extends LitElement {
         users: visibleUsers,
         selectedUserId: selected,
         layout: mode,
-        isAdmin,
+        isAdmin: showAdmin,
         onSelect: (id) => this._onUserSelect(id),
       });
     }


### PR DESCRIPTION
## Summary
- add `only_self` config to Free Drinks card
- hide other users for admins when `only_self` is enabled
- document `only_self` option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c46281f650832eb1b3713302085126