### PR TITLE
Add user credit line to tally card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -8,7 +8,7 @@ Eine Lovelace-Karte für Home Assistant, die Getränkezähler pro Nutzer anzeigt
 
 ## Funktionen
 
-* Zeigt Getränkeanzahl und offenen Betrag pro Nutzer
+* Zeigt Getränkeanzahl, offenen Betrag und Guthaben/Schulden pro Nutzer
 * Getränke hinzufügen oder entfernen mit einstellbarer Schrittweite
 * Automatische Erkennung von Nutzern und Preisen über die Tally‑List‑Integration
 * Sprachunterstützung für Deutsch und Englisch
@@ -71,6 +71,7 @@ Folgende Optionen stehen im UI zur Verfügung:
 * **Maximale Breite (px)** – Begrenzung der Kartenbreite. Standard `500`.
 * **Entfernen-Menü anzeigen** – Ein-/Ausblenden des Menüs zum Entfernen.
 * **Schrittweiten-Auswahl anzeigen** – Schaltflächen zur Auswahl der Schrittweite (1, 3, 5, 10) anzeigen.
+* **Guthaben/Schulden anzeigen** – Zeile mit bereits gezahltem Betrag ein- oder ausblenden.
 * **Nur sich selbst zeigen** – Auswahl auch für Admins auf den eingeloggten Nutzer beschränken.
 * **Namen kürzen** – Namen in der Auswahl abkürzen, bei Bedarf mit weiteren Buchstaben eindeutig halten.
 * **Sprache** – **Auto**, **Deutsch** oder **English** erzwingen.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Lovelace card for Home Assistant that displays drink tallies per user and allo
 
 ## Features
 
-* Shows drink counts per user and the amount owed
+* Shows drink counts per user, the amount owed, and current credit
 * Add or remove drinks with an adjustable step size
 * Automatic user and price detection from the Tally List integration
 * English and German language support with auto detection
@@ -76,6 +76,7 @@ The card offers the following options in the UI:
 * **Maximum width (px)** – Limit card width. Default `500`.
 * **Show remove menu** – Enable/disable the remove-drink dropdown.
 * **Show step selection** – Show buttons to select the step size (1, 3, 5, 10).
+* **Show credit** – Display a line with the amount already paid or owed.
 * **Only show self** – Limit selection to the logged‑in user even for admins.
 * **Shorten user names** – Abbreviate names in the selector while keeping them unique.
 * **User selector** – Choose between **list**, **tabs**, or **grid** for selecting users.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-tally-list-lovelace",
-  "version": "12.09.25",
+  "version": "14.09.25",
   "description": "A simple Lovelace card for showing and updating tally counts per user",
   "main": "tally-list-card.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- show per-user credit (amount already paid or owed) under the free amount
- allow toggling credit line visibility via `show_credit`
- document credit feature and configuration option
- bump card version to 14.09.25

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6d43d84dc832e8465a5255bff8b0e