### PR TITLE
Document free drink feed markdown card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -268,3 +268,19 @@ content: |
   {% endfor %}
 ```
 
+## Freigetränke-Feed Markdown-Karte
+
+Zeigt die letzten Einträge des Freigetränke-Feeds in einer Markdown-Karte.
+
+```yaml
+type: markdown
+content: |
+  {% set all_entries = state_attr('sensor.free_drink_feed','entries') | default([], true) %}
+  {% set entries = all_entries[-5:] | list | reverse %}
+
+  {% for e in entries %}
+  {% set date = as_timestamp(as_datetime(e.time_local)) | timestamp_custom("%d.%m.%Y %H:%M") %}
+  **{{ date }}** — {{ e.name }}: Freigetränke gebucht → {{ e.drinks }} _(„{{ e.comment }}“)_
+  {% endfor %}
+```
+

--- a/README.md
+++ b/README.md
@@ -272,5 +272,21 @@ content: |
   {{ base }} → {% for p in parts %}{{ p | replace(':',': ') }}{{ ', ' if not loop.last else '' }}{% endfor %}
   {% endif %}
   {% endfor %}
-``` 
+```
+
+## Free Drink Feed Markdown Card
+
+Display recent free drink bookings from the free drink feed sensor in a Markdown card.
+
+```yaml
+type: markdown
+content: |
+  {% set all_entries = state_attr('sensor.free_drink_feed','entries') | default([], true) %}
+  {% set entries = all_entries[-5:] | list | reverse %}
+
+  {% for e in entries %}
+  {% set date = as_timestamp(as_datetime(e.time_local)) | timestamp_custom("%d.%m.%Y %H:%M") %}
+  **{{ date }}** — {{ e.name }}: Free drinks booked → {{ e.drinks }} _("{{ e.comment }}")_
+  {% endfor %}
+```
 


### PR DESCRIPTION
## Summary
- add English and German docs for showing free drink feed in a Markdown card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6de70a90c832e99080b326c02dbe9