### PR TITLE
Add option to show sensor icons on tally cards

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -72,6 +72,7 @@ Folgende Optionen stehen im UI zur Verfügung:
 * **Entfernen-Menü anzeigen** – Ein-/Ausblenden des Menüs zum Entfernen.
 * **Schrittweiten-Auswahl anzeigen** – Schaltflächen zur Auswahl der Schrittweite (1, 3, 5, 10) anzeigen.
 * **Guthaben/Schulden anzeigen** – Zeile mit bereits gezahltem Betrag ein- oder ausblenden.
+* **Icons anzeigen** – Sensor-Icon neben dem Getränkenamen anzeigen.
 * **Nur sich selbst zeigen** – Auswahl auch für Admins auf den eingeloggten Nutzer beschränken.
 * **Namen kürzen** – Namen in der Auswahl abkürzen, bei Bedarf mit weiteren Buchstaben eindeutig halten.
 * **Sprache** – **Auto**, **Deutsch** oder **English** erzwingen.
@@ -108,6 +109,7 @@ type: custom:tally-list-free-drinks-card
 Optionen:
 
 * **show_prices** – Preise anzeigen (`true` standardmäßig).
+* **show_icons** – Sensor-Icon neben dem Getränkenamen anzeigen.
 * **comment_presets** – Vordefinierte Kommentarpräfixe. Jedes Element hat `label` und optional `require_comment`.
 * **session_timeout_seconds** – Zeit bis zum automatischen Logout nach dem Login (`30` standardmäßig).
 * **pin_lock_ms** – PIN-Sperrzeit in Millisekunden (`5000` standardmäßig).

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The card offers the following options in the UI:
 * **Show remove menu** – Enable/disable the remove-drink dropdown.
 * **Show step selection** – Show buttons to select the step size (1, 3, 5, 10).
 * **Show credit** – Display a line with the amount already paid or owed.
+* **Show icons** – Display the drink sensor icon next to the name.
 * **Only show self** – Limit selection to the logged‑in user even for admins.
 * **Shorten user names** – Abbreviate names in the selector while keeping them unique.
 * **User selector** – Choose between **list**, **tabs**, or **grid** for selecting users.
@@ -114,6 +115,7 @@ type: custom:tally-list-free-drinks-card
 Options:
 
 * **show_prices** – Display drink prices (`true` by default).
+* **show_icons** – Display the drink sensor icon next to the name.
 * **comment_presets** – Predefine comment prefixes. Each entry has a `label` and optional `require_comment`.
 * **session_timeout_seconds** – Time after login before automatic logout (`30` by default).
 * **pin_lock_ms** – PIN lock duration in milliseconds (`5000` by default).

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -441,6 +441,7 @@ const TL_STRINGS = {
     hide_free: 'Hide people without amount',
     show_step_select: 'Show step selection',
     show_credit: 'Show credit line',
+    show_icons: 'Show drink icons',
     copy_table: 'Copy table',
     copied: 'Copied!',
     reset_all: 'Reset all tallies',
@@ -516,6 +517,7 @@ const TL_STRINGS = {
     hide_free: 'Personen ohne Betrag ausblenden',
     show_step_select: 'Schrittweiten-Auswahl anzeigen',
     show_credit: 'Guthaben/Schulden anzeigen',
+    show_icons: 'Icons anzeigen',
     copy_table: 'Tabelle kopieren',
     copied: 'Kopiert!',
     reset_all: 'Alle Striche zurücksetzen',
@@ -965,6 +967,7 @@ class TallyListCard extends LitElement {
       user_selector: 'list',
       show_step_select: true,
       show_credit: true,
+      show_icons: false,
       ...config,
     };
     this.config.tabs = tabs;
@@ -1038,7 +1041,8 @@ class TallyListCard extends LitElement {
         const cost = count * price;
         total += cost;
         const costStr = this._formatPrice(cost) + ` ${this._currency}`;
-        rows.push({ drink, entity, count, priceStr, costStr, isAvailable, display: drink.charAt(0).toUpperCase() + drink.slice(1) });
+        const icon = stateObj?.attributes?.icon;
+        rows.push({ drink, entity, count, priceStr, costStr, isAvailable, icon, display: drink.charAt(0).toUpperCase() + drink.slice(1) });
       });
 
     if (user.amount_due_entity) deps.add(user.amount_due_entity);
@@ -1205,7 +1209,9 @@ class TallyListCard extends LitElement {
               <td>
                 <button class="action-btn plus plus-btn" data-drink="${r.drink}" @pointerdown=${this._onAddDrink} ?disabled=${this._disabled || !r.isAvailable}>+${this.selectedCount}</button>
               </td>
-              <td>${r.display}</td>
+              <td class="drink">
+                ${this.config.show_icons && r.icon ? html`<ha-icon icon="${r.icon}"></ha-icon>` : ''}${r.display}
+              </td>
               <td>${r.count}</td>
               <td>${r.priceStr}</td>
               <td>${r.costStr}</td>
@@ -1973,6 +1979,14 @@ class TallyListCard extends LitElement {
       border-bottom: 1px solid var(--divider-color);
       text-align: center;
     }
+    td.drink {
+      text-align: left;
+    }
+    td.drink ha-icon {
+      --mdc-icon-size: 20px;
+      margin-right: 4px;
+      vertical-align: middle;
+    }
     button {
       padding: 4px;
     }
@@ -2023,6 +2037,7 @@ class TallyListCardEditor extends LitElement {
       only_self: false,
       show_step_select: true,
       show_credit: true,
+      show_icons: false,
       show_all_users: false,
       show_inactive_drinks: false,
       shorten_user_names: false,
@@ -2080,6 +2095,12 @@ class TallyListCardEditor extends LitElement {
               <label class="switch">
                 ${this._t('show_credit')}
                 <ha-switch .checked=${this._config.show_credit !== false} @change=${this._creditChanged}></ha-switch>
+              </label>
+            </div>
+            <div class="form">
+              <label class="switch">
+                ${this._t('show_icons')}
+                <ha-switch .checked=${this._config.show_icons} @change=${this._iconsChanged}></ha-switch>
               </label>
             </div>
           `
@@ -2206,6 +2227,11 @@ class TallyListCardEditor extends LitElement {
 
   _creditChanged(ev) {
     this._config = { ...this._config, show_credit: ev.target.checked };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _iconsChanged(ev) {
+    this._config = { ...this._config, show_icons: ev.target.checked };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 
@@ -3081,6 +3107,7 @@ customElements.define('tally-due-ranking-card-editor', TallyDueRankingCardEditor
 const FD_STRINGS = {
   en: {
     show_prices: 'Show prices',
+    show_icons: 'Show drink icons',
     version: 'Version',
     card_name: 'Free Drinks Card',
     card_desc: 'Book free drinks with a required comment.',
@@ -3106,6 +3133,7 @@ const FD_STRINGS = {
   },
   de: {
     show_prices: 'Preise anzeigen',
+    show_icons: 'Icons anzeigen',
     version: 'Version',
     card_name: 'Strichliste Freigetränke',
     card_desc: 'Freigetränke mit Pflichtkommentar buchen.',
@@ -3178,6 +3206,7 @@ class TallyListFreeDrinksCardEditor extends LitElement {
     const grid = { columns: 0, ...(config?.grid || {}) };
     this._config = {
       show_prices: true,
+      show_icons: false,
       free_drinks_timer_seconds: 0,
       free_drinks_per_item_limit: 0,
       free_drinks_total_limit: 0,
@@ -3221,6 +3250,12 @@ class TallyListFreeDrinksCardEditor extends LitElement {
               <label class="switch">
                 ${fdT(this.hass, this._config.language, 'show_prices')}
                 <ha-switch .checked=${this._config.show_prices !== false} @change=${this._pricesChanged}></ha-switch>
+              </label>
+            </div>
+            <div class="form">
+              <label class="switch">
+                ${fdT(this.hass, this._config.language, 'show_icons')}
+                <ha-switch .checked=${this._config.show_icons} @change=${this._iconsChanged}></ha-switch>
               </label>
             </div>
             <div class="form">
@@ -3328,6 +3363,11 @@ class TallyListFreeDrinksCardEditor extends LitElement {
 
   _pricesChanged(ev) {
     this._config = { ...this._config, show_prices: ev.target.checked };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  _iconsChanged(ev) {
+    this._config = { ...this._config, show_icons: ev.target.checked };
     fireEvent(this, 'config-changed', { config: this._config });
   }
 
@@ -3646,6 +3686,7 @@ class TallyListFreeDrinksCard extends LitElement {
     const grid = { columns: 0, ...(config?.grid || {}) };
     this.config = {
       show_prices: true,
+      show_icons: false,
       pin_lock_ms: 5000,
       max_width: '500px',
       language: 'auto',
@@ -4126,7 +4167,7 @@ class TallyListFreeDrinksCard extends LitElement {
           (this._drinkNames[drink] || drink)
             .replace(/_/g, ' ')
             .replace(/\b\w/g, (c) => c.toUpperCase());
-        drinks.push({ drink, name });
+        drinks.push({ drink, name, entity: user.drinks[drink] });
       }
     }
     drinks.sort((a, b) => a.name.localeCompare(b.name));
@@ -4158,8 +4199,11 @@ class TallyListFreeDrinksCard extends LitElement {
                 const atPerItemCap = this._perItemCap > 0 && count >= this._perItemCap;
                 const atTotalCap = this._totalCap > 0 && total >= this._totalCap;
                 const disablePlus = atPerItemCap || atTotalCap;
+                const icon = this.config.show_icons ? this.hass.states[d.entity]?.attributes?.icon : null;
                 return html`<tr>
-                  <td>${d.name}</td>
+                  <td class="drink">
+                    ${this.config.show_icons && icon ? html`<ha-icon icon="${icon}"></ha-icon>` : ''}${d.name}
+                  </td>
                   ${showPrices
                     ? html`<td>${this._formatPrice(prices[d.drink])} ${this._currency}</td>`
                     : ''}


### PR DESCRIPTION
## Summary
- add `show_icons` option to display drink sensor icons in tally and free drinks cards
- document new icon setting in English and German READMEs
- prevent icon layout from shifting table columns by tweaking CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6df33b9bc832eb21e1dc35f82fd2e