### PR TITLE
Fix icon alignment for tally list cards

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1985,7 +1985,7 @@ class TallyListCard extends LitElement {
     td.drink ha-icon {
       --mdc-icon-size: 20px;
       margin-right: 4px;
-      vertical-align: middle;
+      vertical-align: -0.15em;
     }
     button {
       padding: 4px;


### PR DESCRIPTION
## Summary
- fix vertical alignment of drink icons in counter and free drinks cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e2966320832e91e457b363b70a5b