### PR TITLE
Fix icon alignment for tally list cards

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1210,7 +1210,9 @@ class TallyListCard extends LitElement {
                 <button class="action-btn plus plus-btn" data-drink="${r.drink}" @pointerdown=${this._onAddDrink} ?disabled=${this._disabled || !r.isAvailable}>+${this.selectedCount}</button>
               </td>
               <td class="drink">
-                ${this.config.show_icons && r.icon ? html`<ha-icon icon="${r.icon}"></ha-icon>` : ''}${r.display}
+                <span class="drink-content">
+                  ${this.config.show_icons && r.icon ? html`<ha-icon icon="${r.icon}"></ha-icon>` : ''}${r.display}
+                </span>
               </td>
               <td>${r.count}</td>
               <td>${r.priceStr}</td>
@@ -1982,10 +1984,13 @@ class TallyListCard extends LitElement {
     td.drink {
       text-align: left;
     }
+    td.drink .drink-content {
+      display: inline-flex;
+      align-items: center;
+    }
     td.drink ha-icon {
       --mdc-icon-size: 20px;
       margin-right: 4px;
-      vertical-align: middle;
     }
     button {
       padding: 4px;
@@ -4202,7 +4207,9 @@ class TallyListFreeDrinksCard extends LitElement {
                 const icon = this.config.show_icons ? this.hass.states[d.entity]?.attributes?.icon : null;
                 return html`<tr>
                   <td class="drink">
-                    ${this.config.show_icons && icon ? html`<ha-icon icon="${icon}"></ha-icon>` : ''}${d.name}
+                    <span class="drink-content">
+                      ${this.config.show_icons && icon ? html`<ha-icon icon="${icon}"></ha-icon>` : ''}${d.name}
+                    </span>
                   </td>
                   ${showPrices
                     ? html`<td>${this._formatPrice(prices[d.drink])} ${this._currency}</td>`


### PR DESCRIPTION
## Summary
- wrap drink cell content with flex container to vertically center icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e2966320832e91e457b363b70a5b