### PR TITLE
Align icons with text in tally list cards

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1981,11 +1981,12 @@ class TallyListCard extends LitElement {
     }
     td.drink {
       text-align: left;
+      display: flex;
+      align-items: center;
     }
     td.drink ha-icon {
       --mdc-icon-size: 20px;
       margin-right: 4px;
-      vertical-align: middle;
     }
     button {
       padding: 4px;
@@ -4323,6 +4324,15 @@ class TallyListFreeDrinksCard extends LitElement {
       padding: 4px;
       border-bottom: 1px solid var(--divider-color);
       text-align: center;
+    }
+    td.drink {
+      text-align: left;
+      display: flex;
+      align-items: center;
+    }
+    td.drink ha-icon {
+      --mdc-icon-size: 20px;
+      margin-right: 4px;
     }
     .actions {
       display: flex;


### PR DESCRIPTION
## Summary
- Vertically align drink icons and text by using flex layout in tables
- Apply consistent icon styling in free drinks card and main tally card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e51db84c832ea93efeabcdcaa4c8