### PR TITLE
Align icons with text in tally list cards

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -1981,6 +1981,7 @@ class TallyListCard extends LitElement {
     }
     td.drink {
       text-align: left;
+      vertical-align: middle;
     }
     td.drink ha-icon {
       --mdc-icon-size: 20px;
@@ -4323,6 +4324,15 @@ class TallyListFreeDrinksCard extends LitElement {
       padding: 4px;
       border-bottom: 1px solid var(--divider-color);
       text-align: center;
+    }
+    td.drink {
+      text-align: left;
+      vertical-align: middle;
+    }
+    td.drink ha-icon {
+      --mdc-icon-size: 20px;
+      margin-right: 4px;
+      vertical-align: middle;
     }
     .actions {
       display: flex;


### PR DESCRIPTION
## Summary
- Vertically center drink icons with their labels using `vertical-align`
- Ensure both main tally and free drinks tables keep proper column alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e51db84c832ea93efeabcdcaa4c8