### PR TITLE
Add admin-only credit card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -275,6 +275,22 @@ content: |
   {% endfor %}
 ```
 
+## Guthaben-Karte
+
+Passe das Guthaben eines Nutzers an. Nur Administratoren können diese Karte benutzen; auf öffentlichen Geräten ist sie deaktiviert.
+
+```yaml
+ type: custom:tally-credit-card
+```
+
+Optionen:
+
+* **max_width** – Maximale Kartenbreite in Pixeln (`500` Standard).
+* **user_selector** – `list`, `tabs` oder `grid`.
+* **shorten_user_names** – Namen in der Auswahl abkürzen.
+* **only_self** – Trotz Admin nur den eigenen Nutzer anzeigen.
+* **language** – Sprache erzwingen: **auto**, **de** oder **en**.
+
 ## Freigetränke-Feed Markdown-Karte
 
 Zeigt die letzten Einträge des Freigetränke-Feeds in einer Markdown-Karte.

--- a/README.md
+++ b/README.md
@@ -276,6 +276,22 @@ content: |
   {% endfor %}
 ```
 
+## Credit Card
+
+Adjust a user's credit. Only administrators can use this card and it is disabled on public devices.
+
+```yaml
+ type: custom:tally-credit-card
+```
+
+Options:
+
+* **max_width** – Maximum card width in pixels (`500` by default).
+* **user_selector** – `list`, `tabs`, or `grid`.
+* **shorten_user_names** – Abbreviate user names in the selector.
+* **only_self** – Only show the current user even for admins.
+* **language** – Force **Auto**, **Deutsch**, or **English**.
+
 ## Free Drink Feed Markdown Card
 
 Display recent free drink bookings from the free drink feed sensor in a Markdown card.

--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -5473,3 +5473,386 @@ class TallySetPinCard extends LitElement {
 
 customElements.define('tally-set-pin-card', TallySetPinCard);
 
+const CREDIT_STRINGS = {
+  en: {
+    card_name: 'Credit Card',
+    card_desc: 'Adjust user credit',
+    amount: 'Amount',
+    add_credit: 'Add credit',
+    remove_credit: 'Remove credit',
+    set_credit: 'Set credit',
+    no_admin: 'Admins only',
+    no_public: 'Unavailable on public devices',
+    success: 'Credit updated',
+    invalid_amount: 'Enter a valid amount',
+    user_not_found: 'User not found',
+  },
+  de: {
+    card_name: 'Guthaben Karte',
+    card_desc: 'Guthaben eines Nutzers anpassen',
+    amount: 'Betrag',
+    add_credit: 'Guthaben hinzufügen',
+    remove_credit: 'Guthaben entfernen',
+    set_credit: 'Guthaben setzen',
+    no_admin: 'Nur für Administratoren',
+    no_public: 'Auf öffentlichen Geräten nicht verfügbar',
+    success: 'Guthaben aktualisiert',
+    invalid_amount: 'Gültigen Betrag eingeben',
+    user_not_found: 'Benutzer nicht gefunden',
+  },
+};
+
+const creditNavLang = detectLang();
+window.customCards.push({
+  type: 'tally-credit-card',
+  name: CREDIT_STRINGS[creditNavLang].card_name,
+  preview: true,
+  description: CREDIT_STRINGS[creditNavLang].card_desc,
+});
+
+class TallyCreditCard extends LitElement {
+  static properties = {
+    hass: {},
+    config: {},
+    selectedUserId: { type: String },
+    _amount: { state: true },
+    _autoUsers: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._uid = crypto?.randomUUID?.() || Math.random().toString(36).slice(2);
+    this.selectedUserId = '';
+    this._amount = '';
+    this._autoUsers = [];
+    this._buckets = new Map();
+    this._tabs = [];
+    this._visibleUsers = [];
+    this._currentTab = 'all';
+    this._sortedUsers = [];
+    this._usersKey = '';
+  }
+
+  setConfig(config) {
+    const tabs = {
+      mode: 'per-letter',
+      grouped_breaks: ['A–E', 'F–J', 'K–O', 'P–T', 'U–Z'],
+      show_all_tab: true,
+      ...(config?.tabs || {}),
+    };
+    const grid = { columns: 0, ...(config?.grid || {}) };
+    this.config = {
+      max_width: '500px',
+      user_selector: 'list',
+      language: 'auto',
+      shorten_user_names: false,
+      only_self: false,
+      ...(config || {}),
+    };
+    this.config.tabs = tabs;
+    this.config.grid = grid;
+    const width = this._normalizeWidth(this.config.max_width);
+    if (width) {
+      this.style.setProperty('--dcc-max-width', width);
+      this.config.max_width = width;
+    } else {
+      this.style.removeProperty('--dcc-max-width');
+      this.config.max_width = '';
+    }
+  }
+
+  _t(key) {
+    return translate(this.hass, this.config.language, CREDIT_STRINGS, key);
+  }
+
+  get _users() {
+    return this.config.users || this._autoUsers || [];
+  }
+
+  get _isAdmin() {
+    return this.hass?.user?.is_admin;
+  }
+
+  _fid(key) {
+    return `tally-${this._uid}-${key}`;
+  }
+
+  _handleSelect(id) {
+    if (id) this.selectedUserId = id;
+  }
+
+  updated(changedProps) {
+    if (changedProps.has('hass')) {
+      if (!this.config.users) {
+        this._autoUsers = this._gatherUsers();
+      }
+      if (this._isAdmin && !this.selectedUserId) {
+        const ownId = this.hass?.user?.id;
+        if (ownId) this.selectedUserId = ownId;
+      }
+    }
+  }
+
+  _gatherUsers() {
+    const users = [];
+    const states = this.hass?.states || {};
+    for (const [entity, state] of Object.entries(states)) {
+      const match = entity.match(/^sensor\.([a-z0-9_]+)_amount_due$/);
+      if (match) {
+        const slug = match[1];
+        if (slug === 'free_drinks') continue;
+        const sensorName = (state.attributes.friendly_name || '')
+          .replace(' Amount Due', '')
+          .replace(' Offener Betrag', '');
+        const person = states[`person.${slug}`];
+        const user_id = person?.attributes?.user_id || null;
+        const name = person?.attributes?.friendly_name || sensorName || slug;
+        users.push({ name, slug, user_id });
+      }
+    }
+    return users;
+  }
+
+  _currentPersonSlugs() {
+    const userId = this.hass?.user?.id;
+    if (!userId) return [];
+    const slugs = [];
+    for (const [entity, state] of Object.entries(this.hass.states)) {
+      if (entity.startsWith('person.') && state.attributes.user_id === userId) {
+        const slug = entity.substring('person.'.length);
+        slugs.push(slug);
+        const alt = fdSlugify(state.attributes.friendly_name || '');
+        if (alt && alt !== slug) slugs.push(alt);
+      }
+    }
+    return slugs;
+  }
+
+  _normalizeWidth(value) {
+    if (!value && value !== 0) return '';
+    const str = String(value).trim();
+    if (str === '') return '';
+    return /^\d+$/.test(str) ? `${str}px` : str;
+  }
+
+  _amountChanged(ev) {
+    this._amount = ev.target.value;
+  }
+
+  async _call(action) {
+    const amt = parseFloat(this._amount);
+    if (isNaN(amt)) {
+      _psToast(this, this._t('invalid_amount'));
+      return;
+    }
+    const users = this._users;
+    const u = users.find(
+      (u) => u.user_id === this.selectedUserId || u.slug === this.selectedUserId || u.name === this.selectedUserId
+    );
+    const user = u?.name || u?.slug;
+    if (!user) {
+      _psToast(this, this._t('user_not_found'));
+      return;
+    }
+    try {
+      await this.hass.callService('tally_list', action, { user: String(user), amount: amt });
+      _psToast(this, this._t('success'));
+      this._amount = '';
+    } catch (e) {
+      const code = e?.error?.code || e?.code || 'error';
+      _psToast(this, String(code));
+    }
+  }
+
+  render() {
+    const width = this._normalizeWidth(this.config.max_width);
+    const cardStyle = width ? `max-width:${width};margin:0 auto;` : '';
+    if (PUBLIC_SESSION.isPublic) {
+      return html`<ha-card style="${cardStyle}"><div class="no-access">${this._t('no_public')}</div></ha-card>`;
+    }
+    if (!this._isAdmin) {
+      return html`<ha-card style="${cardStyle}"><div class="no-access">${this._t('no_admin')}</div></ha-card>`;
+    }
+    const users = this._users;
+    _umEnsureBuckets(this, users);
+    const mode = this.config.user_selector || 'list';
+    const userMenu = _renderUserMenu(
+      this,
+      users,
+      this.selectedUserId,
+      mode,
+      true,
+      (id) => this._handleSelect(id),
+      (u) => u.user_id
+    );
+    const idAmt = this._fid('amt');
+    return html`
+      <ha-card style="${cardStyle}">
+        <div class="content">
+          ${userMenu}
+          <div class="form">
+            <label for="${idAmt}">${this._t('amount')}</label>
+            <input id="${idAmt}" type="number" step="0.01" .value=${this._amount} @input=${this._amountChanged} />
+            <div class="btn-row">
+              <button class="action-btn" @click=${() => this._call('add_credit')}>${this._t('add_credit')}</button>
+              <button class="action-btn" @click=${() => this._call('remove_credit')}>${this._t('remove_credit')}</button>
+              <button class="action-btn" @click=${() => this._call('set_credit')}>${this._t('set_credit')}</button>
+            </div>
+          </div>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  static getConfigElement() {
+    return null;
+  }
+
+  static getStubConfig() {
+    return { max_width: "500px" };
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    .content {
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    ha-card {
+      margin: 0 auto;
+      max-width: var(--dcc-max-width, none);
+    }
+    .user-select {
+      text-align: left;
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      gap: 8px;
+    }
+    .user-actions {
+      border: 1px solid var(--ha-card-border-color, var(--divider-color));
+      border-radius: 14px;
+      background: var(--ha-card-background, #1e1e1e);
+      overflow: hidden;
+    }
+    .alpha-tabs {
+      border-bottom: 1px solid var(--ha-card-border-color, var(--divider-color));
+    }
+    .tabs {
+      display: flex;
+      overflow-x: auto;
+    }
+    .tab {
+      flex: 0 0 auto;
+      padding: 0 12px;
+      height: 44px;
+      background: #2b2b2b;
+      color: #ddd;
+      border: none;
+      border-right: 1px solid var(--ha-card-border-color, var(--divider-color));
+      border-bottom: 1px solid var(--ha-card-border-color, var(--divider-color));
+      font-size: 14px;
+    }
+    .tab:first-child {
+      border-top-left-radius: 14px;
+    }
+    .tab:last-child {
+      border-top-right-radius: 14px;
+      border-right: none;
+    }
+    .alpha-tabs .tab.active {
+      background: var(--success-color, #2e7d32);
+      color: #fff;
+      border-bottom: none;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+    .user-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 12px 16px;
+      margin-top: -1px;
+      border-top: 1px solid var(--ha-card-border-color, var(--divider-color));
+    }
+    .user-chip {
+      position: relative;
+      border-radius: 12px;
+      background: #2b2b2b;
+      color: #ddd;
+      border: none;
+      padding: 0 12px;
+      height: 32px;
+    }
+    .user-chip.active {
+      background: var(--success-color, #2e7d32);
+      color: #fff;
+    }
+    .user-chip.inactive {
+      background: #2b2b2b;
+      color: #ddd;
+    }
+    .user-chip::before {
+      display: none;
+    }
+    .tab:focus,
+    .action-btn:focus,
+    .user-chip:focus {
+      outline: 2px solid rgba(255, 255, 255, 0.25);
+    }
+    .tab:hover,
+    .tab:focus,
+    .action-btn:hover,
+    .action-btn:focus,
+    .user-chip:hover,
+    .user-chip:focus {
+      filter: brightness(1.1);
+    }
+    .user-select select {
+      padding: 0 12px;
+      min-width: 120px;
+      font-size: 14px;
+      height: 44px;
+      line-height: 44px;
+      box-sizing: border-box;
+      border-radius: 12px;
+      border: 1px solid var(--ha-card-border-color);
+      background: var(--btn-neutral, #2b2b2b);
+      color: var(--primary-text-color, #fff);
+      appearance: none;
+    }
+    .form {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .btn-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .action-btn {
+      height: 40px;
+      border-radius: 12px;
+      border: none;
+      cursor: pointer;
+      background: var(--primary-color);
+      color: var(--text-primary-color, #fff);
+      padding: 0 16px;
+    }
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    .no-access {
+      padding: 16px;
+      text-align: center;
+    }
+  `;
+}
+
+customElements.define('tally-credit-card', TallyCreditCard);


### PR DESCRIPTION
## Summary
- add credit management card for admins with add/remove/set actions
- document new credit card in English and German READMEs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e94d04b4832e9c611de8d8dfc727