### PR TITLE
Add admin-only credit card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -275,6 +275,22 @@ content: |
   {% endfor %}
 ```
 
+## Guthaben-Karte
+
+Passe das Guthaben eines Nutzers an. Nur Administratoren können diese Karte benutzen; auf öffentlichen Geräten ist sie deaktiviert.
+
+```yaml
+ type: custom:tally-credit-card
+```
+
+Optionen:
+
+* **max_width** – Maximale Kartenbreite in Pixeln (`500` Standard).
+* **user_selector** – `list`, `tabs` oder `grid`.
+* **shorten_user_names** – Namen in der Auswahl abkürzen.
+* **only_self** – Trotz Admin nur den eigenen Nutzer anzeigen.
+* **language** – Sprache erzwingen: **auto**, **de** oder **en**.
+
 ## Freigetränke-Feed Markdown-Karte
 
 Zeigt die letzten Einträge des Freigetränke-Feeds in einer Markdown-Karte.

--- a/README.md
+++ b/README.md
@@ -276,6 +276,22 @@ content: |
   {% endfor %}
 ```
 
+## Credit Card
+
+Adjust a user's credit. Only administrators can use this card and it is disabled on public devices.
+
+```yaml
+ type: custom:tally-credit-card
+```
+
+Options:
+
+* **max_width** – Maximum card width in pixels (`500` by default).
+* **user_selector** – `list`, `tabs`, or `grid`.
+* **shorten_user_names** – Abbreviate user names in the selector.
+* **only_self** – Only show the current user even for admins.
+* **language** – Force **Auto**, **Deutsch**, or **English**.
+
 ## Free Drink Feed Markdown Card
 
 Display recent free drink bookings from the free drink feed sensor in a Markdown card.


### PR DESCRIPTION
## Summary
- add credit management card for admins with add/remove/set actions
- document new credit card in English and German READMEs
- enable visual editor with color-coded buttons and touch-friendly input field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e94d04b4832e9c611de8d8dfc727