### PR TITLE
feat: add placeholder for amount in credit card

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -5691,12 +5691,13 @@ class TallyCreditCard extends LitElement {
         <div class="content">
           ${userMenu}
           <div class="form">
-            <label for="${idAmt}">${this._t('amount')}</label>
             <input
               id="${idAmt}"
               type="number"
               inputmode="decimal"
               step="0.01"
+              placeholder="${this._t('amount')}"
+              aria-label="${this._t('amount')}"
               .value=${this._amount}
               @input=${this._amountChanged}
             />


### PR DESCRIPTION
## Summary
- show localized amount text as placeholder inside credit card input

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6edc8054c832e910681de68558605