### PR TITLE
fix: support only_self in credit card

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -5673,15 +5673,29 @@ class TallyCreditCard extends LitElement {
     if (!this._isAdmin) {
       return html`<ha-card style="${cardStyle}"><div class="no-access">${this._t('no_admin')}</div></ha-card>`;
     }
-    const users = this._users;
-    _umEnsureBuckets(this, users);
+    let users = this._users;
     const mode = this.config.user_selector || 'list';
+    const current = this.hass?.user;
+    let isAdmin = this._isAdmin;
+    if (this.config.only_self && isAdmin) {
+      users = users.filter(
+        (u) =>
+          u.user_id === current?.id ||
+          u.name === current?.name ||
+          u.slug === current?.name
+      );
+      isAdmin = false;
+      if (current?.id) {
+        this.selectedUserId = current.id;
+      }
+    }
+    _umEnsureBuckets(this, users);
     const userMenu = _renderUserMenu(
       this,
       users,
       this.selectedUserId,
       mode,
-      true,
+      isAdmin,
       (id) => this._handleSelect(id),
       (u) => u.user_id
     );


### PR DESCRIPTION
## Summary
- respect `only_self` option in the credit card to limit admins to their own user

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ee544280832eba501ea4b4e8b0e8