### PR TITLE
Bold credit card buttons and shorter labels

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -5478,9 +5478,9 @@ const CREDIT_STRINGS = {
     card_name: 'Credit Card',
     card_desc: 'Adjust user credit',
     amount: 'Amount',
-    add_credit: 'Add credit',
-    remove_credit: 'Remove credit',
-    set_credit: 'Set credit',
+    add_credit: 'Add',
+    remove_credit: 'Remove',
+    set_credit: 'Set',
     no_admin: 'Admins only',
     no_public: 'Unavailable on public devices',
     success: 'Credit updated',
@@ -5491,9 +5491,9 @@ const CREDIT_STRINGS = {
     card_name: 'Guthaben Karte',
     card_desc: 'Guthaben eines Nutzers anpassen',
     amount: 'Betrag',
-    add_credit: 'Guthaben hinzufügen',
-    remove_credit: 'Guthaben entfernen',
-    set_credit: 'Guthaben setzen',
+    add_credit: 'Hinzufügen',
+    remove_credit: 'Entfernen',
+    set_credit: 'Setzen',
     no_admin: 'Nur für Administratoren',
     no_public: 'Auf öffentlichen Geräten nicht verfügbar',
     success: 'Guthaben aktualisiert',
@@ -5883,6 +5883,7 @@ class TallyCreditCard extends LitElement {
       background: var(--primary-color);
       color: var(--text-primary-color, #fff);
       padding: 0 16px;
+      font-weight: 700;
     }
     .action-btn.add {
       background: var(--success-color, #2e7d32);


### PR DESCRIPTION
## Summary
- Style credit card action buttons with bold text
- Shorten credit card button labels to Add/Remove/Set and Hinzufügen/Entfernen/Setzen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f05a7e24832ebbaa2a625e2b9339