### PR TITLE
Hide user selector for excluded users in set pin card

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -5188,7 +5188,7 @@ class TallySetPinCard extends LitElement {
             : ''
           : ''}
         <div class="content">
-          ${userMenu}
+          ${userFound ? userMenu : ''}
           ${userFound
             ? html`
                 <div class="pin-label">


### PR DESCRIPTION
## Summary
- Hide user selector when the current user is excluded from the set pin card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f139d4d0832e9c3b1030cf68abe6