### PR TITLE
Show error messages before codes in toast

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -5659,8 +5659,13 @@ class TallyCreditCard extends LitElement {
       _psToast(this, this._t('success'));
       this._amount = '';
     } catch (e) {
-      const code = e?.error?.code || e?.code || 'error';
-      _psToast(this, String(code));
+      const msg =
+        e?.error?.message ??
+        e?.message ??
+        e?.error?.code ??
+        e?.code ??
+        'error';
+      _psToast(this, String(msg));
     }
   }
 


### PR DESCRIPTION
## Summary
- update the tally list credit action error handling to prefer message text over error codes

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c9d39fd9f4832e840655e534d8c3db