### PR TITLE
Round set pin card overlay corners

### DIFF
--- a/tally-list-card.js
+++ b/tally-list-card.js
@@ -5336,6 +5336,8 @@ class TallySetPinCard extends LitElement {
       position: relative;
       margin: 0 auto;
       max-width: var(--dcc-max-width, none);
+      border-radius: var(--ha-card-border-radius, 12px);
+      overflow: hidden;
     }
     .warn-overlay {
       position: absolute;
@@ -5350,6 +5352,7 @@ class TallySetPinCard extends LitElement {
       padding: 16px;
       box-sizing: border-box;
       z-index: 2;
+      border-radius: inherit;
     }
     .warn-box {
       background: var(--card-background-color);


### PR DESCRIPTION
## Summary
- add border radius and overflow handling to the set PIN card ha-card wrapper
- inherit the card's corner radius on the warning overlay so it no longer extends past the card edges

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9d637cfac832e90d757b36d0e6b0d